### PR TITLE
Change license text to standard OSI MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,21 +2,19 @@ MIT License
 
 Copyright (c) 2018 Computational Atomic Structure Group
 
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files
-except the above mentioned practical guide GRASP2018 (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
By removing the "except the above mentioned practical guide GRASP2018" part.

This is so that automated systems, such as the one used by GitHub, could recognize that this indeed is the MIT license. Also, the standard open source licenses are [meant to be applied verbatim](https://opensource.org/faq#variant-licenses) without changes to the license text, so, arguably, we shouldn't be calling the current license the "MIT license".

None of the rights granted or restrictions imposed by the license were changed, so the updated wording does not change the spirit of the license in any way. It is clear that "associated documentation files" does not refer to the separate manual, as the manual is not part of the repository and has its own copyright and license statement.

As this touches the license, so I would like explicit permission from a core developer (@cffischer?) for this before it's merged.

