### PR TITLE
CFF autumn patches - update no 3 - csl short format

### DIFF
--- a/src/appl/rbiotransform90/lodcslBio.f90
+++ b/src/appl/rbiotransform90/lodcslBio.f90
@@ -18,6 +18,7 @@
 !...Translated by Pacific-Sierra Research 77to90  4.3E  13:07:22   2/14/04
 !...Modified by Charlotte Froese Fischer
 !                     Gediminas Gaigalas  10/05/17
+!...Modified by Julian Chan 8/16/19
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -187,6 +188,7 @@
     3 CONTINUE
       NCF = NCF + 1
 !
+   1 CONTINUE  ! New Line
       READ (21, '(A)', IOSTAT=IOS) RECORD
 !**********************************************************************
 !blk*
@@ -204,12 +206,29 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(RECORD,'(')/=0) THEN ! New Line
          CALL PRSRCN (RECORD, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 26
+      go to 1 ! New Line
+       ENDIF ! New Line
+
+!
+!   Read the X, J, and (sign of) P quantum numbers
+!
+        IF(INDEX(RECORD,'+')/=0 .OR. INDEX(RECORD,'-')/=0)THEN
+         IF (IOS /= 0) THEN
+            WRITE (ISTDE, *) 'LODCSL: Expecting intermediate ', &
+               'and final angular momentum'
+            WRITE (ISTDE, *) 'quantum number and final parity ', &
+               'specification;'
+            GO TO 26
+         ENDIF
+      go to 2
+      ENDIF
 !
 !   Read the J_sub and v quantum numbers
 !
-         READ (21, '(A)', IOSTAT=IOS) RECORD
+
          IF (IOS /= 0) THEN
             WRITE (ISTDE, *) 'LODCSL: Expecting subshell quantum', &
                ' number specification;'
@@ -218,22 +237,14 @@
          LOC = LEN_TRIM(RECORD)
          CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
          IF (IERR /= 0) GO TO 26
-!
-!   Read the X, J, and (sign of) P quantum numbers
-!
-         READ (21, '(A)', IOSTAT=IOS) RECORD
-         IF (IOS /= 0) THEN
-            WRITE (ISTDE, *) 'LODCSL: Expecting intermediate ', &
-               'and final angular momentum'
-            WRITE (ISTDE, *) 'quantum number and final parity ', &
-               'specification;'
-            GO TO 26
-         ENDIF
+       GO TO 1
+
 !
 !   Allocate additional storage if necessary
 !
 !CFF     It is possible that this should be moved to "3 Continue"
 !        where NCF is incremented
+   2  CONTINUE
          IF (NCF > NCFD) THEN
             NEWSIZ = NCFD + NCFD/2
             CALL RALLOC (IQA,  NNNW,  NEWSIZ, 'IQA',   'LODCSL')

--- a/src/appl/rbiotransform90_mpi/lodcslBio.f90
+++ b/src/appl/rbiotransform90_mpi/lodcslBio.f90
@@ -18,6 +18,7 @@
 !...Translated by Pacific-Sierra Research 77to90  4.3E  13:07:22   2/14/04
 !...Modified by Charlotte Froese Fischer
 !                     Gediminas Gaigalas  10/05/17
+!...Modified by Julian Chan 8/16/19
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -187,6 +188,7 @@
     3 CONTINUE
       NCF = NCF + 1
 !
+   1 CONTINUE  ! New Line
       READ (21, '(A)', IOSTAT=IOS) RECORD
 !**********************************************************************
 !blk*
@@ -204,12 +206,29 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(RECORD,'(')/=0) THEN ! New Line
          CALL PRSRCN (RECORD, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 26
+      go to 1 ! New Line
+       ENDIF ! New Line
+
+!
+!   Read the X, J, and (sign of) P quantum numbers
+!
+        IF(INDEX(RECORD,'+')/=0 .OR. INDEX(RECORD,'-')/=0)THEN
+         IF (IOS /= 0) THEN
+            WRITE (ISTDE, *) 'LODCSL: Expecting intermediate ', &
+               'and final angular momentum'
+            WRITE (ISTDE, *) 'quantum number and final parity ', &
+               'specification;'
+            GO TO 26
+         ENDIF
+      go to 2
+      ENDIF
 !
 !   Read the J_sub and v quantum numbers
 !
-         READ (21, '(A)', IOSTAT=IOS) RECORD
+
          IF (IOS /= 0) THEN
             WRITE (ISTDE, *) 'LODCSL: Expecting subshell quantum', &
                ' number specification;'
@@ -218,22 +237,14 @@
          LOC = LEN_TRIM(RECORD)
          CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
          IF (IERR /= 0) GO TO 26
-!
-!   Read the X, J, and (sign of) P quantum numbers
-!
-         READ (21, '(A)', IOSTAT=IOS) RECORD
-         IF (IOS /= 0) THEN
-            WRITE (ISTDE, *) 'LODCSL: Expecting intermediate ', &
-               'and final angular momentum'
-            WRITE (ISTDE, *) 'quantum number and final parity ', &
-               'specification;'
-            GO TO 26
-         ENDIF
+       GO TO 1
+
 !
 !   Allocate additional storage if necessary
 !
 !CFF     It is possible that this should be moved to "3 Continue"
 !        where NCF is incremented
+   2  CONTINUE
          IF (NCF > NCFD) THEN
             NEWSIZ = NCFD + NCFD/2
             CALL RALLOC (IQA,  NNNW,  NEWSIZ, 'IQA',   'LODCSL')

--- a/src/appl/rcsfinteract90/lodcsl_CSF.f90
+++ b/src/appl/rcsfinteract90/lodcsl_CSF.f90
@@ -11,6 +11,9 @@
 !   Written by  G. Gaigalas                       NIST, December 2015  *
 !                                                                      *
 !***********************************************************************
+!
+!...Modified by Julian Chan 8/16/19
+!
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -75,6 +78,7 @@
 !
     3 CONTINUE
 !
+   1 CONTINUE !New line
       READ (20, '(A)', IOSTAT=IOS) RECORD
       IF (RECORD(1:2) == ' *') THEN
          NEXT_CSF = .FALSE.
@@ -86,25 +90,16 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(RECORD,'(')/=0) THEN ! New Line
          CALL PRSRCN (RECORD, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 26
-!
-!   Read the J_sub and v quantum numbers
-!
-         READ (20, '(A)', IOSTAT=IOS) RECORD
-         IF (IOS /= 0) THEN
-            WRITE (ISTDE, *) 'LODCSL_CSF: Expecting subshell quantum', &
-               ' number specification;'
-            GO TO 26
-         ENDIF
-         C_quant(NCF) = RECORD
-         LOC = LEN_TRIM(RECORD)
-         CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
-         IF (IERR /= 0) GO TO 26
+      go to 1 ! New Line
+      ENDIF ! New Line
+
 !
 !   Read the X, J, and (sign of) P quantum numbers
 !
-         READ (20, '(A)', IOSTAT=IOS) RECORD
+        IF(INDEX(RECORD,'+')/=0 .OR. INDEX(RECORD,'-')/=0)THEN
          IF (IOS /= 0) THEN
             WRITE (ISTDE, *) 'LODCSL_CSF: Expecting intermediate ', &
                'and final angular momentum'
@@ -129,9 +124,25 @@
                ENDIF
             END DO
          ENDIF
+      GO TO 2 !New line
+      ENDIF !New line
+!
+!   Read the J_sub and v quantum numbers
+!
+         IF (IOS /= 0) THEN
+            WRITE (ISTDE, *) 'LODCSL_CSF: Expecting subshell quantum', &
+               ' number specification;'
+            GO TO 26
+         ENDIF
+         C_quant(NCF) = RECORD
+         LOC = LEN_TRIM(RECORD)
+         CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
+         IF (IERR /= 0) GO TO 26
+       GO TO 1 ! New line
 !
 !   Zero out the arrays that store packed integers
 !
+   2  CONTINUE !New line
          DO I = 1,NNNW
             IQA(I,NCF)    = 0
             JQSA(I,1,NCF) = 0

--- a/src/appl/rcsfinteract90/lodcsl_MR.f90
+++ b/src/appl/rcsfinteract90/lodcsl_MR.f90
@@ -11,6 +11,9 @@
 !   Written by  G. Gaigalas                      NIST, December 2015   *
 !                                                                      *
 !***********************************************************************
+!
+!...Modified by Julian Chan 8/16/19
+!
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -83,6 +86,7 @@
     3 CONTINUE
       NCF = NCF + 1
 !
+   1 CONTINUE
       READ (21, '(A)', IOSTAT=IOS) RECORD
       IF (RECORD(1:2) == ' *') THEN
          NBLOCK = NBLOCK + 1
@@ -98,25 +102,16 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(RECORD,'(')/=0) THEN ! New Line
          CALL PRSRCN (RECORD, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 26
-!
-!   Read the J_sub and v quantum numbers
-!
-         IF (IOS /= 0) THEN
-            WRITE (ISTDE, *) 'LODCSL: Expecting subshell quantum', &
-               ' number specification;'
-            GO TO 26
-         ENDIF
-         READ (21, '(A)', IOSTAT=IOS) RECORD
-         C_quant(NCF) = RECORD
-         LOC = LEN_TRIM(RECORD)
-         CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
-         IF (IERR /= 0) GO TO 26
+      go to 1 ! New Line
+       ENDIF ! New Line
+
 !
 !   Read the X, J, and (sign of) P quantum numbers
 !
-         READ (21, '(A)', IOSTAT=IOS) RECORD
+        IF(INDEX(RECORD,'+')/=0 .OR. INDEX(RECORD,'-')/=0)THEN
          IF (IOS /= 0) THEN
             WRITE (ISTDE, *) 'LODCSL: Expecting intermediate ', &
                'and final angular momentum'
@@ -128,9 +123,25 @@
          WRITE(22,'(A)') TRIM(C_shell(NCF))
          WRITE(22,'(A)') TRIM(C_quant(NCF))
          WRITE(22,'(A)') TRIM(C_coupl(NCF))
+      GO TO 2 !New line
+      ENDIF !New line
+!
+!   Read the J_sub and v quantum numbers
+!
+         IF (IOS /= 0) THEN
+            WRITE (ISTDE, *) 'LODCSL: Expecting subshell quantum', &
+               ' number specification;'
+            GO TO 26
+         ENDIF
+         C_quant(NCF) = RECORD
+         LOC = LEN_TRIM(RECORD)
+         CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
+         IF (IERR /= 0) GO TO 26
+       GO TO 1 ! New line
 !
 !   Zero out the arrays that store packed integers
 !
+   2  CONTINUE
          DO I = 1,NNNW
             IQA(I,NCF)    = 0
             JQSA(I,1,NCF) = 0

--- a/src/appl/rmcdhf90/lodcsh2GG.f90
+++ b/src/appl/rmcdhf90/lodcsh2GG.f90
@@ -33,6 +33,7 @@
 !...Translated by Pacific-Sierra Research 77to90  4.3E  12:13:05   2/14/04
 !...Modified by Charlotte Froese Fischer
 !                     Gediminas Gaigalas  10/05/17
+!...Modified by Julian Chan 8/16/19
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -122,6 +123,7 @@
 !GG      NCF = NCF + 1
 !GGGG
 !
+   1 CONTINUE !New line
       READ (NFILE, '(A)', IOSTAT=IOS) STR
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -145,12 +147,30 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(STR,'(')/=0) THEN ! New Line
          CALL PRSRCN (STR, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 28
+      go to 1 ! New Line
+       ENDIF ! New Line
+
+!
+!   Read the X, J, and (sign of) P quantum numbers
+!
+        IF(INDEX(STR,'+')/=0 .OR. INDEX(STR,'-')/=0)THEN
+         IF (IOS /= 0) THEN
+            WRITE (ISTDE, *) MYNAME//': Expecting intermediate ', &
+               'and final angular momentum'
+            WRITE (ISTDE, *) 'quantum number and final parity ', &
+               'specification;'
+            GO TO 26
+         ENDIF
+      GO TO 2 !New line
+      ENDIF !New line
+
 !
 !   Read the J_sub and v quantum numbers
 !
-         READ (nfile,'(A)',IOSTAT = IOS) str
+
          IF (IOS /= 0) THEN
             WRITE (ISTDE, *) MYNAME//': Expecting subshell quantum', &
                ' number specification;'
@@ -159,20 +179,12 @@
          LOC = LEN_TRIM(STR)
          CALL PARSJL (1, NCORE, STR, LOC, IQSUB, NQS, IERR)
          IF (IERR /= 0) GO TO 27
-!
-!   Read the X, J, and (sign of) P quantum numbers
-!
-         READ (nfile,'(A)',IOSTAT = IOS) str
-         IF (IOS /= 0) THEN
-            WRITE (ISTDE, *) MYNAME//': Expecting intermediate ', &
-               'and final angular momentum'
-            WRITE (ISTDE, *) 'quantum number and final parity ', &
-               'specification;'
-            GO TO 26
-         ENDIF
+       GO TO 1 ! New line
+
 !
 !   Zero out the arrays that store packed integers
 !
+   2  CONTINUE
          IQA(:NNNW,NCF) = 0
 !GG         JQSA(:NNNW,1,NCF) = 0
 !GG         JQSA(:NNNW,2,NCF) = 0

--- a/src/appl/rmcdhf90_mpi/lodcsh2GG.f90
+++ b/src/appl/rmcdhf90_mpi/lodcsh2GG.f90
@@ -33,6 +33,7 @@
 !...Translated by Pacific-Sierra Research 77to90  4.3E  12:13:05   2/14/04
 !...Modified by Charlotte Froese Fischer
 !                     Gediminas Gaigalas  10/05/17
+!...Modified by Julian Chan 8/16/19
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -122,6 +123,7 @@
 !GG      NCF = NCF + 1
 !GGGG
 !
+   1 CONTINUE !New line
       READ (NFILE, '(A)', IOSTAT=IOS) STR
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -145,12 +147,30 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(STR,'(')/=0) THEN ! New Line
          CALL PRSRCN (STR, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 28
+      go to 1 ! New Line
+       ENDIF ! New Line
+
+!
+!   Read the X, J, and (sign of) P quantum numbers
+!
+        IF(INDEX(STR,'+')/=0 .OR. INDEX(STR,'-')/=0)THEN
+         IF (IOS /= 0) THEN
+            WRITE (ISTDE, *) MYNAME//': Expecting intermediate ', &
+               'and final angular momentum'
+            WRITE (ISTDE, *) 'quantum number and final parity ', &
+               'specification;'
+            GO TO 26
+         ENDIF
+      GO TO 2 !New line
+      ENDIF !New line
+
 !
 !   Read the J_sub and v quantum numbers
 !
-         READ (nfile,'(A)',IOSTAT = IOS) str
+
          IF (IOS /= 0) THEN
             WRITE (ISTDE, *) MYNAME//': Expecting subshell quantum', &
                ' number specification;'
@@ -159,20 +179,12 @@
          LOC = LEN_TRIM(STR)
          CALL PARSJL (1, NCORE, STR, LOC, IQSUB, NQS, IERR)
          IF (IERR /= 0) GO TO 27
-!
-!   Read the X, J, and (sign of) P quantum numbers
-!
-         READ (nfile,'(A)',IOSTAT = IOS) str
-         IF (IOS /= 0) THEN
-            WRITE (ISTDE, *) MYNAME//': Expecting intermediate ', &
-               'and final angular momentum'
-            WRITE (ISTDE, *) 'quantum number and final parity ', &
-               'specification;'
-            GO TO 26
-         ENDIF
+       GO TO 1 ! New line
+
 !
 !   Zero out the arrays that store packed integers
 !
+   2  CONTINUE
          IQA(:NNNW,NCF) = 0
 !GG         JQSA(:NNNW,1,NCF) = 0
 !GG         JQSA(:NNNW,2,NCF) = 0

--- a/src/appl/rtransition90/lodcslm.f90
+++ b/src/appl/rtransition90/lodcslm.f90
@@ -13,6 +13,7 @@
 !...Translated by Pacific-Sierra Research 77to90  4.3E  07:21:55   1/ 6/07
 !...Modified by Charlotte Froese Fischer
 !                     Gediminas Gaigalas  10/05/17
+!...Modified by Julian Chan 8/16/19
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -164,6 +165,7 @@
     3 CONTINUE
       NCF = NCF + 1
 !
+   1 CONTINUE !New line
       READ (21, '(A)', IOSTAT=IOS) RECORD
 !**********************************************************************
 !blk*
@@ -177,12 +179,30 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(RECORD,'(')/=0) THEN ! New Line
          CALL PRSRCN (RECORD, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 26
+      go to 1 ! New Line
+       ENDIF ! New Line
+
+!
+!   Read the X, J, and (sign of) P quantum numbers
+!
+       IF(INDEX(RECORD,'+')/=0 .OR. INDEX(RECORD,'-')/=0)THEN
+         IF (IOS /= 0) THEN
+            WRITE (6, *) 'LODCSL: Expecting intermediate'
+            WRITE (6, *) ' and final angular momentum'
+            WRITE (6, *) ' quantum number and final parity'
+            WRITE (6, *) ' specification;'
+            GO TO 26
+         ENDIF
+      GO TO 2 !New line
+      ENDIF !New line
+
 !
 !   Read the J_sub and v quantum numbers
 !
-         READ (21, '(A)', IOSTAT=IOS) RECORD
+
          IF (IOS /= 0) THEN
             WRITE (6, *) 'LODCSL: Expecting subshell quantum'
             WRITE (6, *) ' number specification;'
@@ -191,20 +211,12 @@
          LOC = LEN_TRIM(RECORD)
          CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
          IF (IERR /= 0) GO TO 26
-!
-!   Read the X, J, and (sign of) P quantum numbers
-!
-         READ (21, '(A)', IOSTAT=IOS) RECORD
-         IF (IOS /= 0) THEN
-            WRITE (6, *) 'LODCSL: Expecting intermediate'
-            WRITE (6, *) ' and final angular momentum'
-            WRITE (6, *) ' quantum number and final parity'
-            WRITE (6, *) ' specification;'
-            GO TO 26
-         ENDIF
+       GO TO 1 ! New line
+
 !
 !   Allocate additional storage if necessary
 !
+   2  CONTINUE ! New line
          IF (NCF > NCFD) THEN
             NEWSIZ = NCFD + NCFD/2
             CALL RALLOC (IQA, NNNW, NEWSIZ, 'IQA', 'LODCSLM')

--- a/src/appl/rtransition90_mpi/lodcslm.f90
+++ b/src/appl/rtransition90_mpi/lodcslm.f90
@@ -13,6 +13,7 @@
 !...Translated by Pacific-Sierra Research 77to90  4.3E  07:21:55   1/ 6/07
 !...Modified by Charlotte Froese Fischer
 !                     Gediminas Gaigalas  10/05/17
+!...Modified by Julian Chan 8/16/19
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -63,7 +64,7 @@
 !
 !   Entry message
 !
-!      WRITE (6, *) 'Loading Configuration Symmetry List File ...'
+!     WRITE (6, *) 'Loading Configuration Symmetry List File ...'
 !
 !   Get the list of subshells
 !
@@ -103,8 +104,8 @@
 !
       IF (NW > 1) THEN
          CALL CONVRT (NW, RECORD, LENTH)
-!         WRITE (6, *) ' there are '//RECORD(1:LENTH)//&
-!            ' relativistic subshells;'
+         WRITE (6, *) ' there are '//RECORD(1:LENTH)//&
+            ' relativistic subshells;'
       ELSE
          WRITE (6, *) ' there is 1 relativistic subshell;'
       ENDIF
@@ -164,6 +165,7 @@
     3 CONTINUE
       NCF = NCF + 1
 !
+   1 CONTINUE !New line
       READ (21, '(A)', IOSTAT=IOS) RECORD
 !**********************************************************************
 !blk*
@@ -177,12 +179,30 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(RECORD,'(')/=0) THEN ! New Line
          CALL PRSRCN (RECORD, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 26
+      go to 1 ! New Line
+       ENDIF ! New Line
+
+!
+!   Read the X, J, and (sign of) P quantum numbers
+!
+       IF(INDEX(RECORD,'+')/=0 .OR. INDEX(RECORD,'-')/=0)THEN
+         IF (IOS /= 0) THEN
+            WRITE (6, *) 'LODCSL: Expecting intermediate'
+            WRITE (6, *) ' and final angular momentum'
+            WRITE (6, *) ' quantum number and final parity'
+            WRITE (6, *) ' specification;'
+            GO TO 26
+         ENDIF
+      GO TO 2 !New line
+      ENDIF !New line
+
 !
 !   Read the J_sub and v quantum numbers
 !
-         READ (21, '(A)', IOSTAT=IOS) RECORD
+
          IF (IOS /= 0) THEN
             WRITE (6, *) 'LODCSL: Expecting subshell quantum'
             WRITE (6, *) ' number specification;'
@@ -191,20 +211,12 @@
          LOC = LEN_TRIM(RECORD)
          CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
          IF (IERR /= 0) GO TO 26
-!
-!   Read the X, J, and (sign of) P quantum numbers
-!
-         READ (21, '(A)', IOSTAT=IOS) RECORD
-         IF (IOS /= 0) THEN
-            WRITE (6, *) 'LODCSL: Expecting intermediate'
-            WRITE (6, *) ' and final angular momentum'
-            WRITE (6, *) ' quantum number and final parity'
-            WRITE (6, *) ' specification;'
-            GO TO 26
-         ENDIF
+       GO TO 1 ! New line
+
 !
 !   Allocate additional storage if necessary
 !
+   2  CONTINUE ! New line
          IF (NCF > NCFD) THEN
             NEWSIZ = NCFD + NCFD/2
             CALL RALLOC (IQA, NNNW, NEWSIZ, 'IQA', 'LODCSLM')
@@ -440,8 +452,8 @@
                   IF (JQS(3,I,J) /= JQS(3,I,NCF)) GO TO 17
                END DO
                DO I = 1, NOPEN - 1
-!                  WRITE (6, *) I
-!                  WRITE (6, *) JCUP(I,J), JCUP(I,NCF)
+!                 WRITE (6, *) I
+!                 WRITE (6, *) JCUP(I,J), JCUP(I,NCF)
                   IF (JCUP(I,J) /= JCUP(I,NCF)) GO TO 17
                END DO
             END DO
@@ -519,8 +531,8 @@
 !   All done; report
 !
       CALL CONVRT (NCF, RECORD, LENTH)
-!      WRITE (6, *) ' there are '//RECORD(1:LENTH)//' relativistic CSFs;'
-!      WRITE (6, *) ' ... load complete;'
+      WRITE (6, *) ' there are '//RECORD(1:LENTH)//' relativistic CSFs;'
+      WRITE (6, *) ' ... load complete;'
 !
 !   Debug printout
 !

--- a/src/lib/lib9290/lodcsl.f90
+++ b/src/lib/lib9290/lodcsl.f90
@@ -18,6 +18,7 @@
 !...Translated by Pacific-Sierra Research 77to90  4.3E  13:07:22   2/14/04
 !...Modified by Charlotte Froese Fischer
 !                     Gediminas Gaigalas  10/05/17
+!...Modified by Julian Chan 8/16/19
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -173,6 +174,7 @@
     3 CONTINUE
       NCF = NCF + 1
 !
+   1 CONTINUE ! New line
       READ (21, '(A)', IOSTAT=IOS) RECORD
 !**********************************************************************
 !blk*
@@ -190,12 +192,29 @@
 !   Read in the occupations (q) of the peel shells; stop with a
 !   message if an error occurs
 !
+       IF(INDEX(RECORD,'(')/=0) THEN ! New Line
          CALL PRSRCN (RECORD, NCORE, IOCC, IERR)
          IF (IERR /= 0) GO TO 26
+      go to 1 ! New Line
+       ENDIF ! New Line
+
+!
+!   Read the X, J, and (sign of) P quantum numbers
+!
+       IF(INDEX(RECORD,'+')/=0 .OR. INDEX(RECORD,'-')/=0)THEN
+         IF (IOS /= 0) THEN
+            WRITE (ISTDE, *) 'LODCSL: Expecting intermediate ', &
+               'and final angular momentum'
+            WRITE (ISTDE, *) 'quantum number and final parity ', &
+               'specification;'
+            GO TO 26
+         ENDIF
+      GO TO 2 !New line
+      ENDIF !New line
+
 !
 !   Read the J_sub and v quantum numbers
 !
-         READ (21, '(A)', IOSTAT=IOS) RECORD
          IF (IOS /= 0) THEN
             WRITE (ISTDE, *) 'LODCSL: Expecting subshell quantum', &
                ' number specification;'
@@ -204,22 +223,14 @@
          LOC = LEN_TRIM(RECORD)
          CALL PARSJL (1, NCORE, RECORD, LOC, IQSUB, NQS, IERR)
          IF (IERR /= 0) GO TO 26
-!
-!   Read the X, J, and (sign of) P quantum numbers
-!
-         READ (21, '(A)', IOSTAT=IOS) RECORD
-         IF (IOS /= 0) THEN
-            WRITE (ISTDE, *) 'LODCSL: Expecting intermediate ', &
-               'and final angular momentum'
-            WRITE (ISTDE, *) 'quantum number and final parity ', &
-               'specification;'
-            GO TO 26
-         ENDIF
+      GO TO 1  ! New line
+
 !
 !   Allocate additional storage if necessary
 !
 !CFF     It is possible that this should be moved to "3 Continue"
 !        where NCF is incremented
+   2  CONTINUE ! New line
          IF (NCF > NCFD) THEN
             NEWSIZ = NCFD + NCFD/2
             CALL RALLOC (IQA,  NNNW,  NEWSIZ, 'IQA',   'LODCSL')

--- a/src/lib/lib9290/setcsll.f90
+++ b/src/lib/lib9290/setcsll.f90
@@ -9,6 +9,7 @@
 !...Translated by Pacific-Sierra Research 77to90  4.3E  10:50:34   2/14/04
 !...Modified by Charlotte Froese Fischer
 !                     Gediminas Gaigalas  10/05/17
+!...Modified by Julian Chan 8/12/19
 !-----------------------------------------------
 !   I n t e r f a c e   B l o c k s
 !-----------------------------------------------
@@ -29,11 +30,12 @@
 !-----------------------------------------------
       INTEGER :: I, NCSF, IOS, IERR
       LOGICAL :: FOUND
-      CHARACTER :: STR*15, CH*2, LINE3*200
+      CHARACTER :: STR*15, CH*2, LINE3*200, ID*8
 !-----------------------------------------------
 ! Locals
 
 ! Look for  <name>
+      Print *, 'Entering SETCSLL'
 
       INQUIRE(FILE=NAME, EXIST=FOUND)
       IF (.NOT.FOUND) THEN
@@ -71,8 +73,11 @@
 
       IOS = 0
       DO WHILE(IOS == 0)
-         READ (NUNIT, '(1A2)', IOSTAT=IOS) CH
-         IF (CH==' *' .OR. IOS/=0) THEN
+         READ (NUNIT, '(A)', IOSTAT=IOS) LINE3
+       IF (INDEX(LINE3,'(')/=0) THEN
+         READ (NUNIT, '(A)', IOSTAT=IOS) LINE3
+       ENDIF
+         IF (INDEX(LINE3,'*')/=0 .OR. IOS/=0) THEN
             !.. a new block has been found
             NBLOCK = NBLOCK + 1
             WRITE (6, *) 'Block ', NBLOCK, ',  ncf = ', NCSF
@@ -81,21 +86,24 @@
                WRITE (6, *) 'Maximum allowed is ', NBLKIN
                STOP
             ENDIF
-            I = LEN_TRIM(LINE3)
-            IDBLK(NBLOCK) = LINE3(I-4:I)
+            IDBLK(nblock) = ID
             NCFBLK(NBLOCK) = NCSF
             NCSF = 0
             IF (IOS == 0) CYCLE
          ELSE
-            READ (NUNIT, *)
-            READ (NUNIT, '(A)') LINE3
-            NCSF = NCSF + 1
+       IF(INDEX(LINE3,'+')/=0 .OR. INDEX(LINE3,'-')/=0)THEN
+           NCSF = NCSF + 1
+                I = LEN_TRIM(LINE3)
+                ID = LINE3(I-4:I)
+         ENDIF
          ENDIF
       END DO
 
 ! Obtain ncftot
 
       NCFTOT = SUM(NCFBLK(:NBLOCK))
+
+     WRITE(*,*) 'NCFBLK NBLOCK',NCFBLK(1),NCFBLK(2),NCFBLK(3),NBLOCK
 
       RETURN
       END SUBROUTINE SETCSLL

--- a/src/tool/rcsfsplit.f90
+++ b/src/tool/rcsfsplit.f90
@@ -4,12 +4,12 @@ program rcsfsplit
 
 implicit none
 integer :: i, j, k, n, nlayer, norb, norblayer, nsymmetrymatch, norbcomp, ncsf, nwrite, ncount
-integer :: jr, jl, pos, ncsflist(50)
-character(len=200) :: string1, string2, string3, name
+integer :: ios, jr, jl, pos, ncsflist(50)
+character(len=100) :: string,  name
 character(len=1500) :: orbitalstring
 character(len=3) :: orb(300),orbital(25),orbcomp(300)
 character(len=4) :: orbrel(300)
-character(len=200) :: orbitallayer,label(50)
+character(len=100) :: orbitallayer,label(50)
 
 write(*,*) 'RCSFSPLIT'
 write(*,*) 'Splits a list name.c of CSFs into a number of lists with CSFs that '
@@ -29,11 +29,11 @@ open(unit=36,file=trim(name)//'.c',status='old')
 
 ! Read five first line save line four containing the string of orbitals
 
-read(36,'(a)') string1
-read(36,'(a)') string1
-read(36,'(a)') string1
+read(36,'(a)') string
+read(36,'(a)') string
+read(36,'(a)') string
 read(36,'(a)') orbitalstring
-read(36,'(a)') string1
+read(36,'(a)') string
 
 ! Number of orbitals
 
@@ -110,12 +110,12 @@ do k = 1,nlayer
    end do
 
    rewind(36)
-   read(36,'(a)') string1
-   write(48+k,'(a)') trim(string1)
-   read(36,'(a)') string1
-   write(48+k,'(a)') trim(string1)
-   read(36,'(a)') string1
-   write(48+k,'(a)') trim(string1)
+   read(36,'(a)') string
+   write(48+k,'(a)') trim(string)
+   read(36,'(a)') string
+   write(48+k,'(a)') trim(string)
+   read(36,'(a)') string
+   write(48+k,'(a)') trim(string)
    read(36,'(a)') orbitalstring
 
 !  Find out and write the orbitals for this layer in relativistic notation
@@ -139,36 +139,31 @@ do k = 1,nlayer
       end if
    end do
    write(48+k,'(a)') trim(orbitalstring)
-   read(36,'(a)') string1
-   write(48+k,'(a)') trim(string1)
+   read(36,'(a)') string
+   write(48+k,'(a)') trim(string)
 
+! Modified by cff 09/03/19 for shorter format
    ncsf = 0
+   read(36,'(a)') string
    do
-      read(36,'(a)',end=99) string1
-      if (string1(2:2).eq.'*') then
-         write(48+k,'(a)') trim(string1)
-         read(36,'(a)') string1
-      end if
-      read(36,'(a)') string2
-      read(36,'(a)') string3
-
 !  A CSF should be kept if there are no complementary orbitals in the string
-
+!     string here is always a configuration
       n = 0
       do i = 1,norbcomp
-         n = index(trim(string1),orbcomp(i))
+         n = index(trim(string),orbcomp(i))
          if (n.ne.0) exit
       end do
-      if (n.eq.0) then
-         write(48+k,'(a)') trim(string1)
-         write(48+k,'(a)') trim(string2)
-         write(48+k,'(a)') trim(string3)
-         ncsf = ncsf + 1
-      end if
+      if (n.eq.0) write(48+k,'(a)') trim(string)
+      Do
+         read(36,'(a)', end=99) string
+         if (index(string, '(') .ne. 0) exit
+         if (n.eq.0) then
+            write(48+k,'(a)') trim(string)
+            if (scan(string, '+-') .ne. 0) ncsf= ncsf+1
+         end if
+      end do
    end do
-
 99 continue
-
    ncsflist(k) = ncsf
 end do
 


### PR DESCRIPTION
Implementation of @cffischer's proposed shorter and more informative format for `<name>.c` configuration state functions lists (CSL's). The ´lodcsl´ implementations are done by Julian Chan @julian0506.

**Short explanation of the format by CFF:** Basically, the new structure is by configuration, but for each configuration all the couplings are shown along with critical seniority numbers. So far, our code does not support CSFs where extra information is needed. This will be important for the g-shell which I think someone should work on with Gediminas' new `rangular`
   If GRASP were a well designed program, changing the format for reading `<name>.c` would require a change of only one `lod` routine, but GRASP is not well designed so little changes were needed in quite a few places. 

**To do 1:** I've cleaned up the codes I got from CFF a bit, removing traling whites, tab-chars and windows-style line endings. Some work remains on the new code bits  though, like getting rid of backwards pointing go-to/continue pairs.

**To do 2:** We need a version of `rcsfgenerate` to create lists on this format right? Which SiRan @rsi103027 has made an attempt on if I understand things correctly, but with some work remaining? (something with 3f orbitals?). For now, the example below is provided in an attached zip file.

**Example:** 5f4 (attached to this pull request for testing purposes:  [csl_5f4.zip](https://github.com/compas/grasp/files/3785480/csl_5f4.zip))
```
Core subshells:

Peel subshells:
  5f-  5f
CSF(s):
  5f ( 4)
        0
         0+
  5f-( 1)  5f ( 3)
      5/2      5/2
                  0+
  5f-( 2)  5f ( 2)
        0        0
                  0+
        2        2
                  0+
        4        4
                  0+
  5f-( 4)
        0
         0+
 *
  5f-( 1)  5f ( 3)
      5/2      7/2
                  1+
      5/2      3/2
                  1+
      5/2      5/2
                  1+
  5f-( 2)  5f ( 2)
        2        2
                  1+
        4        4
                  1+
  5f-( 3)  5f ( 1)
      5/2      7/2
                  1+
      9/2      7/2
                  1+
  ...
  ..
  .
```