### PR TITLE
lib9290: User ERROR STOP instead of STOP in CONVRT

### DIFF
--- a/src/lib/lib9290/convrt.f90
+++ b/src/lib/lib9290/convrt.f90
@@ -44,7 +44,7 @@
 !
       IF (LENTH > LEN(CNUM)) THEN
          WRITE (6, *) 'CONVRT: Length of CNUM inadeuate.'
-         STOP
+         ERROR STOP
       ELSE
          IF (LENTH <= 9) THEN
             FORM = '(1I'//C19(LENTH)//')'

--- a/src/lib/lib9290/convrt2.f90
+++ b/src/lib/lib9290/convrt2.f90
@@ -49,7 +49,7 @@
 !
       IF (LENTH > LEN(CNUM)) THEN
          WRITE (ISTDE, *) 'CONVRT: Length of CNUM inadeuate. (from:', FROM, ')'
-         STOP
+         ERROR STOP
       ELSE
          IF (LENTH <= 9) THEN
             FORM = '(1I'//C19(LENTH)//')'

--- a/src/lib/lib9290/convrt_double.f90
+++ b/src/lib/lib9290/convrt_double.f90
@@ -52,7 +52,7 @@
 !
       IF (LENTH > LEN(CNUM)) THEN
          WRITE (6, *) 'CONVRT_DOUBLE: Length of CNUM inadeuate.'
-         STOP
+         ERROR STOP
       ELSE
          IF (LENTH <= 9) THEN
             FORM = '(1I'//C19(LENTH)//')'
@@ -64,7 +64,7 @@
          IF(mod(INTNUM,2) /= 0) THEN
             IF (LENTH+2 > LEN(CNUM)) THEN
                WRITE (6, *) 'CONVRT_DOUBLE: Length of CNUM inadeuate.'
-               STOP
+               ERROR STOP
             ELSE
                CNUM(1:LENTH+2) = CNUM(1:LENTH)//'/2'
                LENTH = LENTH + 2


### PR DESCRIPTION
If the string passed to `CONVRT` is not long enough, it terminates the program, which is an error condition. This should terminate with `ERROR STOP` so that (1) we'd get a non-zero exit code, and (2) we'd get a stacktrace to help identify where the crash occurred.

Came up when debugging #33.