### PR TITLE
Don't run GitHub Actions on: pull_request

### DIFF
--- a/.github/workflows/buildfiles.yml
+++ b/.github/workflows/buildfiles.yml
@@ -1,6 +1,6 @@
 name: Verify build files
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/buildmake.yml
+++ b/.github/workflows/buildmake.yml
@@ -1,6 +1,6 @@
 name: Build with Make
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
`on: [pull_request, push]` creates two identical build jobs on a pull request, which is unnecessary. The `on: push` builds should already show up under the PR checks.