### PR TITLE
rcsfgenerate bug fix by C. Y. Chen 

### DIFF
--- a/src/appl/rcsfgenerate90/matain.f90
+++ b/src/appl/rcsfgenerate90/matain.f90
@@ -262,7 +262,7 @@
                      if (Y(1:1).GE.'0' .AND. Y(1:1).LE.'9') then
                         if (org(i,j).GT.0) then
                            tmp = ICHAR(Y(1:1))-ICHAR('0')
-                           if (Y(2:2).GE.'1' .AND. Y(2:2).LE.'9')      &
+                           if (Y(2:2).GE.'0' .AND. Y(2:2).LE.'9')      &
                               tmp = tmp*10 + ICHAR(Y(2:2))-ICHAR('0')
                            low(i,j) = min(org(i,j),tmp)
                         endif
@@ -312,7 +312,7 @@
                      if (Y(1:1).GE.'0' .AND. Y(1:1).LE.'9') then
                         if (org(i,j).GT.0) then
                            tmp = ICHAR(Y(1:1))-ICHAR('0')
-                           if (Y(2:2).GE.'1' .AND. Y(2:2).LE.'9')      &
+                           if (Y(2:2).GE.'0' .AND. Y(2:2).LE.'9')      &
                               tmp = tmp*10 + ICHAR(Y(2:2))-ICHAR('0')
                            low(i,j) = min(org(i,j),tmp)
                         endif


### PR DESCRIPTION
The long overdue `rcsfgenerate` bug fix by Chen in PR: #45 is moved to this separate PR, to get it into master as soon as possible.

Lines 265 and 315 of `matain.f90` are changed according to:

```
if (Y(2:2).GE.'1' .AND. Y(2:2).LE.'9')      &
              -->
if (Y(2:2).GE.'0' .AND. Y(2:2).LE.'9')      &
```