### PR TITLE
Use ubuntu-18.04 images on CI (again)

### DIFF
--- a/.github/workflows/buildfiles.yml
+++ b/.github/workflows/buildfiles.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/buildmake.yml
+++ b/.github/workflows/buildmake.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Tests
 # feature branches to be namespaced as <prefix>/<branch>.
 on:
   push:
-    branches: '*'
+    branches: '**'
     tags: '**'
   pull_request:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Tests
 # feature branches to be namespaced as <prefix>/<branch>.
 on:
   push:
-    branches: '**'
+    branches: '*'
     tags: '**'
   pull_request:
 


### PR DESCRIPTION
Works around #59 by switching back to the old images for now so that the MPI tests would pass again.