### PR TITLE
New version of RCSFINTERACT (2021)

### DIFF
--- a/src/appl/rcsfinteract90/RCSFinteract.f90
+++ b/src/appl/rcsfinteract90/RCSFinteract.f90
@@ -9,6 +9,7 @@
 !   This program is a slight modification of the GENMCP program        *
 !                                                                      *
 !   Written by  G. Gaigalas                   NIST, December 2015      *
+!   Modification by G. Gaigalas                          May 2021      *
 !                                                                      *
 !***********************************************************************
 !-----------------------------------------------
@@ -42,7 +43,7 @@
       print *, "RCSFinteract: Determines all the CSFs (rcsf.inp) that interact"
       print *, "              with the CSFs in the multireference (rcsfmr.inp)"
       print *, "              (C)  Copyright by G. Gaigalas and Ch. F. Fischer"
-      print *, "              (Fortran 95 version)               NIST  (2017)."
+      print *, "              (Fortran 95 version)               NIST  (2021)."
       print *, "              Input files: rcsfmr.inp, rcsf.inp"
       print *, "              Output file: rcsf.out"
       print *, ""

--- a/src/appl/rcsfinteract90/set_CSF_list.f90
+++ b/src/appl/rcsfinteract90/set_CSF_list.f90
@@ -8,6 +8,7 @@
 !   Call(s) to: [RCI92]: LENGTH, OPENFL.                               *
 !                                                                      *
 !   Written by  G. Gaigalas                   NIST, December 2015      *
+!   Modified by G. Gaigalas                            04/21/2021      *
 !                                                                      *
 !***********************************************************************
 !-----------------------------------------------
@@ -86,10 +87,13 @@
 !
       READ (21, '(A)') S_orbitals_1
       READ (20, '(A)') S_orbitals_2
-!      I = LEN_TRIM(S_orbitals_1)
-!      IF(S_orbitals_1(1:I) /= S_orbitals_2(1:I)) then
-!         STOP "Different order of Peel orbitals"
-!      end if
+      I = LEN_TRIM(S_orbitals_1)
+      IF(S_orbitals_1(1:I) /= S_orbitals_2(1:I)) then
+         WRITE (6, *) ''
+         WRITE (6, *) 'Error in input !!!'
+         WRITE (6, *) 'Different order of Peel orbitals'
+         STOP ' in files rcsfmr.inp and rcsf.inp'
+      end if
       WRITE (22, '(A)') TRIM(S_orbitals_2)
 !
       READ (21, '(1A7)', IOSTAT=IOS) RECORD_1

--- a/src/appl/rcsfinteract90/set_CSF_list.f90
+++ b/src/appl/rcsfinteract90/set_CSF_list.f90
@@ -92,7 +92,7 @@
          WRITE (6, *) ''
          WRITE (6, *) 'Error in input !!!'
          WRITE (6, *) 'Different order of Peel orbitals'
-         STOP ' in files rcsfmr.inp and rcsf.inp'
+         ERROR STOP ' in files rcsfmr.inp and rcsf.inp'
       end if
       WRITE (22, '(A)') TRIM(S_orbitals_2)
 !


### PR DESCRIPTION
Critical bug fix by G. Gaigalas (May, 2021)

This version addresses a bug related to mismatching peel sheel ordering
in the multireference and full list. This can happen for larger, more
complex systems where correlation orbitals added in higher layers, might
end up before spectroscopic orbitals in the list of peel shells, using
standard ordering. This can lead to that a lot of CSF's are removed in
the reduction that should in fact be in there, just that the peel order
is different. The present proposed fix by Gediminas adds an
additional check for this which increases the runtime, but is necessary
to avoid critical mistakes that may pass unnoticed.

This bug fix is to consider as critical and should be adopted by all
users who make use of CSF list reductions using this code immediately.

The main change is the addition of the following (row 90-96) lines in `set_CSF_list.f90`

```fortran
      I = LEN_TRIM(S_orbitals_1)
      IF(S_orbitals_1(1:I) /= S_orbitals_2(1:I)) then
         WRITE (6, *) ''
         WRITE (6, *) 'Error in input !!!'
         WRITE (6, *) 'Different order of Peel orbitals'
         STOP ' in files rcsfmr.inp and rcsf.inp'
      end if
```
You can also press "Files changed" in the menu above - where you can also comment in individual lines etc by pressing the plus sign in the code - don't worry if you do something strange, we can always revert things.

Since this is critical we should try to merge this within a few days - **I will give you until Friday this week.**

Feel free to comment and suggest additional improvements!

Cheers,
Jon