### PR TITLE
Allow overriding default compiler flag in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,15 +99,31 @@ set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR})
 
 # Additional Fortran compiler flags.
 #
-# -fno-automatic: this was set in the original make_environment_gfortran_UBC file.
+#   -fno-automatic: this was set in the original make_environment_gfortran_UBC file.
 #
-# Note: optimization should be enabled on the Release target automatically.
+# Note: there is no need to pass optimization flags explicitly (e.g. -O2) -- CMake enables
+# -O2 automatically on the Release target. Similarly, -g is automatically set for the Debug
+# target.
 #
-# If need be, you can also set up linker flags. E.g.:
+# To set additional compiler flags, you can set CMAKE_Fortran_FLAGS when invoking CMake.
+# For example
 #
-#     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgfortran")
+#   cmake -DCMAKE_Fortran_FLAGS="-fno-automatic -fconvert=big-endian" ..
 #
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-automatic")
+# Note: this will override the defaults, so you need to pass -fno-automatic yourself. This
+# behavior is useful when using e.g. the Intel compiler, which has a different name for this
+# option, and so you don't want to pass a For GFortran-specific flag.
+#
+# Similarly, additional linker options can be passed via CMAKE_EXE_LINKER_FLAGS, e.g.
+#
+#   cmake -DCMAKE_EXE_LINKER_FLAGS="-static-libgfortran" ..
+#
+if(NOT DEFINED CMAKE_Fortran_FLAGS)
+    set(CMAKE_Fortran_FLAGS "-fno-automatic")
+else()
+    message("CMAKE_Fortran_FLAGS set by user to: ${CMAKE_Fortran_FLAGS}")
+    message("Note: GRASP requires -fno-automatic (or equivalent)")
+endif()
 
 message("Compiler flags etc. for this GRASP build:")
 message("* CMAKE_BUILD_TYPE:               ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
(This only affects the CMake build)

Currently, we always pass `-fno-automatic` as a compiler flag, even if the user adds their own flags (by setting `CMAKE_Fortran_FLAGS`). This is a problem for e.g. `ifort` which has a different name for that flag.

With this change, if the user decides to customize the flags by passing their own `CMAKE_Fortran_FLAGS`, we no longer set `-fno-automatic` automatically, which solves that problem. The only thing to note though is that the user then needs to explicitly pass `-fno-automatic`.

**Question to anyone who might know this:** do we actually _need_ `-fno-automatic` for GRASP? It changes the way `SAVE` attributes are handled.. but is there any part in GRASP that actually requires this flag?