### PR TITLE
Makefile default gfortran additions

### DIFF
--- a/Make.user.gfortran
+++ b/Make.user.gfortran
@@ -1,0 +1,5 @@
+export FC = gfortran
+export FC_FLAGS = -O3 -fno-automatic
+export FC_LD =
+export FC_MPI= mpifort
+export OMPI_FC=${FC}

--- a/Make.user.ifort
+++ b/Make.user.ifort
@@ -1,0 +1,4 @@
+export FC = ifort
+export FC_FLAGS = -O2 -save
+export FC_LD = -mkl=sequential
+export FC_MPI = mpiifort

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ endif
 
 # Variables affecting the GRASP build. These can be overridden in Make.user or via
 # environment variables.
+export FC ?= gfortran
 export FC_FLAGS ?= -O2 -fno-automatic
 export FC_LD ?=
 export FC_MPI ?= mpifort

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ builds are defined and documented at the beginning of the `Makefile`.
 
 For the user it should never be necessary to modify the `Makefile` itself. Rather, a
 `Make.user` file can be create next to the main `Makefile` where the build variables can be
-overridden. E.g. to use the Intel Fortran compiler instead, you may want to create the
-following `Make.user` file:
+overridden. E.g. to use the Intel Fortran compiler instead, you may want to create the following
+`Make.user` file:
 
 ```make
 export FC = ifort
@@ -135,6 +135,8 @@ set `FC_LD` as follows:
 ```make
 export FC_LD = -L /path/to/blas
 ```
+
+The repository also contains the `Make.user.gfortran` and `Make.user.ifort` files, which can be used as templates for your own `Make.user` file.
 
 ## About GRASP
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ builds are defined and documented at the beginning of the `Makefile`.
 
 For the user it should never be necessary to modify the `Makefile` itself. Rather, a
 `Make.user` file can be create next to the main `Makefile` where the build variables can be
-overridden. E.g. to use the Intel Fortran compiler instead, you may want to create the following
-`Make.user` file:
+overridden. E.g. to use the Intel Fortran compiler instead, you may want to create the
+following `Make.user` file:
 
 ```make
 export FC = ifort


### PR DESCRIPTION
Added default `FC=gfortran` specification in the Makefile, which already defines default gfortran flags.

Also added suggested Make.user files for gfortran and ifort, that can then be used as a basis for further modifications.