### PR TITLE
Use ERROR STOP instead of STOP in rmcdhf

### DIFF
--- a/src/appl/rmcdhf90/getaldwt.f90
+++ b/src/appl/rmcdhf90/getaldwt.f90
@@ -48,7 +48,7 @@
          WRITE (ISTDE, *) 'Input not correct, do it again. tried=', I
       END DO
 
-      IF (I > 10) STOP 'Must be running un-attended'
+      IF (I > 10) ERROR STOP 'Must be running un-attended'
 
 !------------------------------------------------------------------
 
@@ -82,7 +82,7 @@
 
       CASE DEFAULT
          WRITE (ISTDE, *) 'Impossible ! Because it was guarded'
-         STOP
+         ERROR STOP
       END SELECT
 
       SUMWGT = 1.D0/SUMWGT

--- a/src/appl/rmcdhf90/getold.f90
+++ b/src/appl/rmcdhf90/getold.f90
@@ -155,7 +155,7 @@
          END DO
          NOFFSET = NOFFSET + NEVBLK(JBLOCK)
       END DO
-      IF (NOFFSET /= NCMIN) STOP 'getold: ncmin trouble'
+      IF (NOFFSET /= NCMIN) ERROR STOP 'getold: ncmin trouble'
 
       RETURN
       END SUBROUTINE GETOLD

--- a/src/appl/rmcdhf90/getoldwt.f90
+++ b/src/appl/rmcdhf90/getoldwt.f90
@@ -54,7 +54,7 @@
         WRITE(734,*) n159,'! level weights'
       END IF
 
-      IF (I > 10) STOP
+      IF (I > 10) ERROR STOP
 
 !------------------------------------------------------------------
 
@@ -89,7 +89,7 @@
 
       CASE DEFAULT
          WRITE (ISTDE, *) 'Impossible ! Because it was guarded'
-         STOP
+         ERROR STOP
       END SELECT
 
       RETURN

--- a/src/appl/rmcdhf90/improv.f90
+++ b/src/appl/rmcdhf90/improv.f90
@@ -110,7 +110,7 @@
          ELSE
             IF (MYID == 0) WRITE (*, 301)
             !CALL TIMER (0)
-            STOP
+            ERROR STOP
          ENDIF
       ENDIF
 !

--- a/src/appl/rmcdhf90/in.f90
+++ b/src/appl/rmcdhf90/in.f90
@@ -115,7 +115,7 @@
          WRITE (6, *) ' dimensional limit (currently '//CNUM(1:LCNUM)//');'
          WRITE (6, *) ' radial wavefunction may indicate a'
          WRITE (6, *) ' continuum state.'
-         STOP
+         ERROR STOP
       ENDIF
 !
 !   Compute required elements of remaining rows of  L  and  U

--- a/src/appl/rmcdhf90/lodcsh2GG.f90
+++ b/src/appl/rmcdhf90/lodcsh2GG.f90
@@ -427,7 +427,7 @@
 
       IF (NCF /= NCFBLOCK) THEN
          WRITE (ISTDE, *) MYNAME//': ncf=', NCF, 'ncfblock=', NCFBLOCK
-         STOP
+         ERROR STOP
       ENDIF
 !
 !   Check if any subshell is empty; eliminate it from the
@@ -455,7 +455,7 @@
 !      NELEC = NCOREL+NPEEL
       IF (NCOREL + NPEEL /= NELEC) THEN
          WRITE (ISTDE, *) MYNAME//': nelec not equal to that in lodcsh'
-         STOP
+         ERROR STOP
       ENDIF
       WRITE (6,*)'There are ',NCF,' relativistic CSFs... load complete;'
       RETURN
@@ -474,5 +474,5 @@
    29 continue
       CLOSE(NFILE)
 
-      STOP
+      ERROR STOP
       END SUBROUTINE LODCSH2GG

--- a/src/appl/rmcdhf90/matrix.f90
+++ b/src/appl/rmcdhf90/matrix.f90
@@ -121,7 +121,7 @@
 !=======================================================================
 
          READ (30) MCPLAB, JBLOCKT, NCF
-         IF (JBLOCKT/=JBLOCK .OR. NCF/=NCFBLK(JBLOCK)) STOP &
+         IF (JBLOCKT/=JBLOCK .OR. NCF/=NCFBLK(JBLOCK)) ERROR STOP &
             'matrx: jblockt .NE. jblock .OR. ncf1 .NE. ncf2'
          READ (30) NELMNTGG
          NELMNT = INT8(NELMNTGG)
@@ -150,8 +150,8 @@
          IF (NEVBLK(JBLOCK) == 0) THEN
             DO NFILE = 31, 32 + KMAXF
                READ (NFILE) MCPLAB, JBLOCKT, NCFT, NCOEFF
-               IF (JBLOCKT /= JBLOCK) STOP 'matrx: jblockt .NE. jblock'
-               IF (NCFT /= NCF) STOP 'matrx: ncft .NE. ncf'
+               IF (JBLOCKT /= JBLOCK) ERROR STOP 'matrx: jblockt .NE. jblock'
+               IF (NCFT /= NCF) ERROR STOP 'matrx: ncft .NE. ncf'
 
                READ (NFILE) LAB, NCONTR
                DO WHILE(LAB/=0 .OR. NCONTR/=0)

--- a/src/appl/rmcdhf90/rscfvu.f90
+++ b/src/appl/rmcdhf90/rscfvu.f90
@@ -137,7 +137,7 @@
 
       CALL SETMCP (NCORE, NBLK0, IDBLK, 'mcp')
       CALL SETCSL ('rcsf.inp', NCORE1, IDBLK)
-      IF (NCORE /= NCORE1) STOP 'rscfvu: ncore'
+      IF (NCORE /= NCORE1) ERROR STOP 'rscfvu: ncore'
 
 !=======================================================================
 !  Gather all remaining information and perform some setup. This

--- a/src/appl/rmcdhf90/setcof.f90
+++ b/src/appl/rmcdhf90/setcof.f90
@@ -262,7 +262,7 @@
          READ (30) MCPLAB, JBLOCKT, NCF
          IF (JBLOCKT /= JBLOCK) THEN
             WRITE (ISTDE, *) MYNAME, '1: jblockt .NE. jblock'
-            STOP
+            ERROR STOP
          ENDIF
          READ (30) NELMNTGG
          NELMNT = INT8(NELMNTGG)
@@ -273,7 +273,7 @@
          READ (31) MCPLAB, JBLOCKT, NCF, NCOEFF
          IF (JBLOCKT /= JBLOCK) THEN
             WRITE (ISTDE, *) MYNAME, '2: jblockt .NE. jblock'
-            STOP
+            ERROR STOP
          ENDIF
 
          !*** Loop over labels having non-zero coefficients
@@ -399,7 +399,7 @@
             READ (30) MCPLAB, JBLOCKT, NCF
             IF (JBLOCKT /= JBLOCK) THEN
                WRITE (ISTDE, *) MYNAME, ':3 jblockt .NE. jblock'
-               STOP
+               ERROR STOP
             ENDIF
             READ (30) NELMNTGG
             NELMNT = INT8(NELMNTGG)
@@ -409,7 +409,7 @@
             READ (NFILE) MCPLAB, JBLOCKT, NCF, NCOEFF
             IF (JBLOCKT /= JBLOCK) THEN
                WRITE (ISTDE, *) MYNAME, ':4 jblockt .NE. jblock'
-               STOP
+               ERROR STOP
             ENDIF
 
             K = NFILE - 32                       ! multipolarity of the integral
@@ -496,7 +496,7 @@
                   EXIT
                END DO
 
-               IF (ITHIS == (-911)) STOP 'ithis .EQ. -911'
+               IF (ITHIS == (-911)) ERROR STOP 'ithis .EQ. -911'
 
                !*** Check ithis against the previously recorded ***
                IF (JBLOCK > 1) THEN
@@ -665,7 +665,7 @@
                   ITHIS2 = ((IORB*KEY + IYO2)*KEY + IYO1)*KEY + K
                END DO
 
-               IF (ITHIS==(-911) .OR. ITHIS2==(-911)) STOP 'ithis2'
+               IF (ITHIS==(-911) .OR. ITHIS2==(-911)) ERROR STOP 'ithis2'
 
                !*** Check the previously recorded for YA
                IF (JBLOCK > 1) THEN

--- a/src/appl/rmcdhf90/setcsl.f90
+++ b/src/appl/rmcdhf90/setcsl.f90
@@ -56,14 +56,14 @@
       CALL OPENFL (21, NAME, 'FORMATTED', 'OLD', IERR)
       IF (IERR == 1) THEN
          WRITE (6, *) 'Error when opening ', NAME(1:LEN_TRIM(NAME))
-         STOP
+         ERROR STOP
       ENDIF
 
       READ (21, '(1A15)', IOSTAT=IOS) STR
       IF (IOS/=0 .OR. STR/='Core subshells:') THEN
          WRITE (6, *) 'Not a Configuration Symmetry List File;'
          CLOSE(21)
-         STOP
+         ERROR STOP
       ENDIF
 
       !..Load header of <name> file

--- a/src/appl/rmcdhf90/setham.f90
+++ b/src/appl/rmcdhf90/setham.f90
@@ -224,11 +224,11 @@
 
       IF (JBLOCKT /= JBLOCK) THEN
          WRITE (ISTDE, *) MYNAME, ': blk1=', JBLOCKT, ' blk2=', JBLOCK
-         STOP
+         ERROR STOP
       ENDIF
       IF (NCFT /= NCF) THEN
          WRITE (ISTDE, *) MYNAME, ': ncf1 = ', NCFT, ' ncf2 = ', NCF
-         STOP
+         ERROR STOP
       ENDIF
 
 !=======================================================================
@@ -236,7 +236,7 @@
 !=======================================================================
 
       READ (31, IOSTAT=IOS) LAB, NCONTR
-      IF (IOS /= 0) STOP 'IOS .NE. 0 when reading LAB, NCONTR'
+      IF (IOS /= 0) ERROR STOP 'IOS .NE. 0 when reading LAB, NCONTR'
       DO WHILE(LAB/=0 .OR. NCONTR/=0)
 
          !*** decode the label of I(ab)
@@ -264,14 +264,14 @@
             IF (LOD > NELMNT) THEN
                WRITE (6, *) '  Error in computing 1-e contribution'
                WRITE (6, *) '  LOC = ', LOC , '  NELMNT = ', NELMNT
-               STOP
+               ERROR STOP
             ENDIF
             EMT(LOC) = EMT(LOC) + TEGRAL*COEFF(I)
          END DO
 
          READ (31, IOSTAT=IOS) LAB, NCONTR
          IF (IOS == 0) CYCLE
-         STOP 'IOS .NE. 0 when reading LAB, NCONTR'
+         ERROR STOP 'IOS .NE. 0 when reading LAB, NCONTR'
       END DO
 
 !=======================================================================
@@ -285,11 +285,11 @@
 
          IF (JBLOCKT /= JBLOCK) THEN
             WRITE (ISTDE, *) MYNAME, ': blk3=', JBLOCKT, ' blk4=', JBLOCK
-            STOP
+            ERROR STOP
          ENDIF
          IF (NCFT /= NCF) THEN
             WRITE (ISTDE, *) MYNAME, ': ncf3 = ', NCFT, ' ncf4 = ', NCF
-            STOP
+            ERROR STOP
          ENDIF
 
 !=======================================================================
@@ -297,7 +297,7 @@
 !=======================================================================
 
          READ (NFILE, IOSTAT=IOS) LAB, NCONTR
-         IF (IOS /= 0) STOP 'IOS .NE. 0 when reading LAB, NCONTR 2'
+         IF (IOS /= 0) ERROR STOP 'IOS .NE. 0 when reading LAB, NCONTR 2'
          DO WHILE(LAB/=0 .OR. NCONTR/=0)
 
             !                         k
@@ -330,14 +330,14 @@
                IF (LOD > NELMNT) THEN   !! NELMENT (from Hmat_C) is INT*8
                   WRITE (6, *) '  Error in computing 2-e contribution'
                   WRITE (6, *) '  LOC= ', LOC , '  NELMNT = ', NELMNT
-                  STOP
+                  ERROR STOP
                ENDIF
                EMT(LOC) = EMT(LOC) + TEGRAL*COEFF(I)
             END DO
 
             READ (NFILE, IOSTAT=IOS) LAB, NCONTR
             IF (IOS == 0) CYCLE
-            STOP 'IOS .NE. 0 when reading LAB, NCONTR 2'
+            ERROR STOP 'IOS .NE. 0 when reading LAB, NCONTR 2'
          END DO
       END DO
 

--- a/src/appl/rmcdhf90/setmcp.f90
+++ b/src/appl/rmcdhf90/setmcp.f90
@@ -79,7 +79,7 @@
       IERROR = IERROR + ABS(IOS)
       IF (NBLOCK>NBLKIN .OR. NBLOCK<1) THEN
          WRITE (ISTDE, *) 'setmcp: nblock = ', NBLOCK
-         STOP
+         ERROR STOP
       ENDIF
 
 !cjb allocate ncfblk(0:*)
@@ -105,7 +105,7 @@
 
       IF (.NOT.FOUND) THEN
          WRITE (ISTDE, *) 'The mcp files do not exist'
-         STOP
+         ERROR STOP
       ENDIF
 
 !  Open the files; check file headers
@@ -124,7 +124,7 @@
          IF (MYID/=MYIDD .OR. NPROCS/=NPROCSS) THEN
             WRITE (ISTDE, *) 'mcp files were generated under different', &
                ' processor configuration.'
-            STOP
+            ERROR STOP
          ENDIF
 
          IF (MCPLAB /= 'MCP') THEN
@@ -142,7 +142,7 @@
          DO I = 30, K
             CLOSE(I)
          END DO
-         STOP
+         ERROR STOP
       END DO
 
       RETURN

--- a/src/appl/rmcdhf90/setmix.f90
+++ b/src/appl/rmcdhf90/setmix.f90
@@ -48,7 +48,7 @@
       CALL OPENFL (25, NAME, 'UNFORMATTED', 'NEW', IERR)
       IF (IERR /= 0) THEN
          WRITE (ISTDE, *) 'Error when opening ', NAME(1:LEN_TRIM(NAME))
-         STOP
+         ERROR STOP
       ENDIF
 !
 !   Write the file header

--- a/src/appl/rmcdhf90/setsum.f90
+++ b/src/appl/rmcdhf90/setsum.f90
@@ -31,7 +31,7 @@
       CALL OPENFL (24, FILNAM, FORM, STATUS, IERR)
       IF (IERR /= 0) THEN
          WRITE (ISTDE, *) 'Error when opening ', FILNAM
-         STOP
+         ERROR STOP
       ENDIF
 
       RETURN

--- a/src/appl/rmcdhf90_mpi/getaldwt.f90
+++ b/src/appl/rmcdhf90_mpi/getaldwt.f90
@@ -48,7 +48,7 @@
          WRITE (ISTDE, *) 'Input not correct, do it again. tried=', I
       END DO
 
-      IF (I > 10) STOP 'Must be running un-attended'
+      IF (I > 10) ERROR STOP 'Must be running un-attended'
 
 !------------------------------------------------------------------
 
@@ -82,7 +82,7 @@
 
       CASE DEFAULT
          WRITE (ISTDE, *) 'Impossible ! Because it was guarded'
-         STOP
+         ERROR STOP
       END SELECT
 
       SUMWGT = 1.D0/SUMWGT

--- a/src/appl/rmcdhf90_mpi/getoldmpi.f90
+++ b/src/appl/rmcdhf90_mpi/getoldmpi.f90
@@ -198,7 +198,7 @@
          END DO
          NOFFSET = NOFFSET + NEVBLK(JBLOCK)
       END DO
-      IF (NOFFSET /= NCMIN) STOP 'getold: ncmin trouble'
+      IF (NOFFSET /= NCMIN) ERROR STOP 'getold: ncmin trouble'
 
       RETURN
       END SUBROUTINE GETOLDmpi

--- a/src/appl/rmcdhf90_mpi/getoldwt.f90
+++ b/src/appl/rmcdhf90_mpi/getoldwt.f90
@@ -57,7 +57,7 @@
         WRITE(734,*) n159,'! level weights'
       END IF
 
-      IF (I > 10) STOP
+      IF (I > 10) ERROR STOP
 
 !------------------------------------------------------------------
 
@@ -87,7 +87,7 @@
 
       CASE DEFAULT
          WRITE (ISTDE, *) 'Impossible ! Because it was guarded'
-         STOP
+         ERROR STOP
       END SELECT
 
       RETURN

--- a/src/appl/rmcdhf90_mpi/improvmpi.f90
+++ b/src/appl/rmcdhf90_mpi/improvmpi.f90
@@ -222,7 +222,7 @@
          ELSE
             IF (MYID == 0) WRITE (*, 301)
             !CALL TIMER (0)
-            STOP
+            ERROR STOP
          ENDIF
       ENDIF
 !

--- a/src/appl/rmcdhf90_mpi/in.f90
+++ b/src/appl/rmcdhf90_mpi/in.f90
@@ -116,7 +116,7 @@
          WRITE (6, *) ' dimensional limit (currently '//CNUM(1:LCNUM)//');'
          WRITE (6, *) ' radial wavefunction may indicate a'
          WRITE (6, *) ' continuum state.'
-         STOP
+         ERROR STOP
       ENDIF
 !
 !   Compute required elements of remaining rows of  L  and  U

--- a/src/appl/rmcdhf90_mpi/lodcsh2GG.f90
+++ b/src/appl/rmcdhf90_mpi/lodcsh2GG.f90
@@ -427,7 +427,7 @@
 
       IF (NCF /= NCFBLOCK) THEN
          WRITE (ISTDE, *) MYNAME//': ncf=', NCF, 'ncfblock=', NCFBLOCK
-         STOP
+         ERROR STOP
       ENDIF
 !
 !   Check if any subshell is empty; eliminate it from the
@@ -455,7 +455,7 @@
 !      NELEC = NCOREL+NPEEL
       IF (NCOREL + NPEEL /= NELEC) THEN
          WRITE (ISTDE, *) MYNAME//': nelec not equal to that in lodcsh'
-         STOP
+         ERROR STOP
       ENDIF
       WRITE (6,*)'There are ',NCF,' relativistic CSFs... load complete;'
       RETURN
@@ -474,5 +474,5 @@
    29 continue
       CLOSE(NFILE)
 
-      STOP
+      ERROR STOP
       END SUBROUTINE LODCSH2GG

--- a/src/appl/rmcdhf90_mpi/matrixmpi.f90
+++ b/src/appl/rmcdhf90_mpi/matrixmpi.f90
@@ -118,7 +118,7 @@
 !=======================================================================
 
          READ (30) MCPLAB, JBLOCKT, NCF
-         IF (JBLOCKT/=JBLOCK .OR. NCF/=NCFBLK(JBLOCK)) STOP &
+         IF (JBLOCKT/=JBLOCK .OR. NCF/=NCFBLK(JBLOCK)) ERROR STOP &
             'MATRIXMPI: jblockt .NE. jblock .OR. ncf1 .NE. ncf2'
          READ (30) NELMNTGG
          NELMNT = INT8(NELMNTGG)
@@ -147,8 +147,8 @@
             DO NFILE = 31, 32 + KMAXF
                READ (NFILE) MCPLAB, JBLOCKT, NCFT, NCOEFF
                IF (JBLOCKT /= JBLOCK)                  &
-                          STOP 'MATRIXmpi: jblockt .NE. jblock'
-               IF (NCFT /= NCF) STOP 'MATRIXmpi: ncft .NE. ncf'
+                          ERROR STOP 'MATRIXmpi: jblockt .NE. jblock'
+               IF (NCFT /= NCF) ERROR STOP 'MATRIXmpi: ncft .NE. ncf'
 
                READ (NFILE) LAB, NCONTR
                DO WHILE(LAB/=0 .OR. NCONTR/=0)

--- a/src/appl/rmcdhf90_mpi/rscfmpivu.f90
+++ b/src/appl/rmcdhf90_mpi/rscfmpivu.f90
@@ -138,7 +138,7 @@
       CALL SETMCP (NCORE, NBLK0, IDBLK, 'mcp' // idstring)
       if(myid == 0) file_rcsl = permdir(1:lenperm)//'/rcsf.inp'
       CALL SETCSLmpi (file_rcsl, ncore1, idblk)
-      IF (NCORE /= NCORE1) STOP 'rscfmpivu: ncore'
+      IF (NCORE /= NCORE1) ERROR STOP 'rscfmpivu: ncore'
 
 !=======================================================================
 !  Gather all remaining information and perform some setup. This

--- a/src/appl/rmcdhf90_mpi/setcof.f90
+++ b/src/appl/rmcdhf90_mpi/setcof.f90
@@ -247,7 +247,7 @@
          READ (30) MCPLAB, JBLOCKT, NCF
          IF (JBLOCKT /= JBLOCK) THEN
             WRITE (ISTDE, *) MYNAME, '1: jblockt .NE. jblock'
-            STOP
+            ERROR STOP
          ENDIF
          READ (30) NELMNTGG
          NELMNT = INT8(NELMNTGG)
@@ -258,7 +258,7 @@
          READ (31) MCPLAB, JBLOCKT, NCF, NCOEFF
          IF (JBLOCKT /= JBLOCK) THEN
             WRITE (ISTDE, *) MYNAME, '2: jblockt .NE. jblock'
-            STOP
+            ERROR STOP
          ENDIF
 
          !*** Loop over labels having non-zero coefficients
@@ -379,7 +379,7 @@
             READ (30) MCPLAB, JBLOCKT, NCF
             IF (JBLOCKT /= JBLOCK) THEN
                WRITE (ISTDE, *) MYNAME, ':3 jblockt .NE. jblock'
-               STOP
+               ERROR STOP
             ENDIF
             READ (30) NELMNTGG
             NELMNT = INT8(NELMNTGG)
@@ -389,7 +389,7 @@
             READ (NFILE) MCPLAB, JBLOCKT, NCF, NCOEFF
             IF (JBLOCKT /= JBLOCK) THEN
                WRITE (ISTDE, *) MYNAME, ':4 jblockt .NE. jblock'
-               STOP
+               ERROR STOP
             ENDIF
 
             K = NFILE - 32                       ! multipolarity of the integral
@@ -476,7 +476,7 @@
                   EXIT
                END DO
 
-               IF (ITHIS == (-911)) STOP 'ithis .EQ. -911'
+               IF (ITHIS == (-911)) ERROR STOP 'ithis .EQ. -911'
 
                !*** Check ithis against the previously recorded ***
                IF (JBLOCK > 1) THEN
@@ -624,7 +624,7 @@
                   ITHIS2 = ((IORB*KEY + IYO2)*KEY + IYO1)*KEY + K
                END DO
 
-               IF (ITHIS==(-911) .OR. ITHIS2==(-911)) STOP 'ithis2'
+               IF (ITHIS==(-911) .OR. ITHIS2==(-911)) ERROR STOP 'ithis2'
 
                !*** Check the previously recorded for YA
                IF (JBLOCK > 1) THEN

--- a/src/appl/rmcdhf90_mpi/setcslmpi.f90
+++ b/src/appl/rmcdhf90_mpi/setcslmpi.f90
@@ -57,7 +57,7 @@
          CALL OPENFL (21, name, 'FORMATTED', 'OLD', ierr)
          IF (ierr .EQ. 1) THEN
             PRINT *, 'Error when opening ',name(1:LEN_TRIM (name))
-            STOP
+            ERROR STOP
          ENDIF
 
          READ (21,'(1A15)',IOSTAT = ios) str
@@ -65,7 +65,7 @@
                (str .NE. 'Core subshells:')) THEN
             PRINT *, 'Not a Configuration Symmetry List File;'
             CLOSE (21)
-            STOP
+            ERROR STOP
          ENDIF
 
          !..Load header of <name> file

--- a/src/appl/rmcdhf90_mpi/setham.f90
+++ b/src/appl/rmcdhf90_mpi/setham.f90
@@ -225,11 +225,11 @@
 
       IF (JBLOCKT /= JBLOCK) THEN
          WRITE (ISTDE, *) MYNAME, ': blk1=', JBLOCKT, ' blk2=', JBLOCK
-         STOP
+         ERROR STOP
       ENDIF
       IF (NCFT /= NCF) THEN
          WRITE (ISTDE, *) MYNAME, ': ncf1 = ', NCFT, ' ncf2 = ', NCF
-         STOP
+         ERROR STOP
       ENDIF
 
 !=======================================================================
@@ -237,7 +237,7 @@
 !=======================================================================
 
       READ (31, IOSTAT=IOS) LAB, NCONTR
-      IF (IOS /= 0) STOP 'IOS .NE. 0 when reading LAB, NCONTR'
+      IF (IOS /= 0) ERROR STOP 'IOS .NE. 0 when reading LAB, NCONTR'
       DO WHILE(LAB/=0 .OR. NCONTR/=0)
 
          !*** decode the label of I(ab)
@@ -265,14 +265,14 @@
             IF (LOD > (NELMNT)) THEN
                WRITE (6, *) '  Error in computing 1-e contribution'
                WRITE (6, *) '  LOC = ', LOC, '  NELMNT = ', (NELMNT)
-               STOP
+               ERROR STOP
             ENDIF
             EMT(LOC) = EMT(LOC) + TEGRAL*COEFF(I)
          END DO
 
          READ (31, IOSTAT=IOS) LAB, NCONTR
          IF (IOS == 0) CYCLE
-         STOP 'IOS .NE. 0 when reading LAB, NCONTR'
+         ERROR STOP 'IOS .NE. 0 when reading LAB, NCONTR'
       END DO
 
 !=======================================================================
@@ -286,11 +286,11 @@
 
          IF (JBLOCKT /= JBLOCK) THEN
             WRITE (ISTDE, *) MYNAME, ': blk3=', JBLOCKT, ' blk4=', JBLOCK
-            STOP
+            ERROR STOP
          ENDIF
          IF (NCFT /= NCF) THEN
             WRITE (ISTDE, *) MYNAME, ': ncf3 = ', NCFT, ' ncf4 = ', NCF
-            STOP
+            ERROR STOP
          ENDIF
 
 !=======================================================================
@@ -298,7 +298,7 @@
 !=======================================================================
 
          READ (NFILE, IOSTAT=IOS) LAB, NCONTR
-         IF (IOS /= 0) STOP 'IOS .NE. 0 when reading LAB, NCONTR 2'
+         IF (IOS /= 0) ERROR STOP 'IOS .NE. 0 when reading LAB, NCONTR 2'
          DO WHILE(LAB/=0 .OR. NCONTR/=0)
 
             !                         k
@@ -331,14 +331,14 @@
                IF (LOD > NELMNT) THEN
                   WRITE (6, *) '  Error in computing 2-e contribution'
                   WRITE (6, *) '  LOC = ', LOC, '  NELMNT = ', NELMNT
-                  STOP
+                  ERROR STOP
                ENDIF
                EMT(LOC) = EMT(LOC) + TEGRAL*COEFF(I)
             END DO
 
             READ (NFILE, IOSTAT=IOS) LAB, NCONTR
             IF (IOS == 0) CYCLE
-            STOP 'IOS .NE. 0 when reading LAB, NCONTR 2'
+            ERROR STOP 'IOS .NE. 0 when reading LAB, NCONTR 2'
          END DO
       END DO
 

--- a/src/appl/rmcdhf90_mpi/setmcp.f90
+++ b/src/appl/rmcdhf90_mpi/setmcp.f90
@@ -79,7 +79,7 @@
       IERROR = IERROR + ABS(IOS)
       IF (NBLOCK>NBLKIN .OR. NBLOCK<1) THEN
          WRITE (ISTDE, *) 'setmcp: nblock = ', NBLOCK
-         STOP
+         ERROR STOP
       ENDIF
 
 !cjb allocate ncfblk(0:*)
@@ -105,7 +105,7 @@
 
       IF (.NOT.FOUND) THEN
          WRITE (ISTDE, *) 'The mcp files do not exist'
-         STOP
+         ERROR STOP
       ENDIF
 
 !  Open the files; check file headers
@@ -124,7 +124,7 @@
          IF (MYID/=MYIDD .OR. NPROCS/=NPROCSS) THEN
             WRITE (ISTDE, *) 'mcp files were generated under different', &
                ' processor configuration.'
-            STOP
+            ERROR STOP
          ENDIF
 
          IF (MCPLAB /= 'MCP') THEN
@@ -142,7 +142,7 @@
          DO I = 30, K
             CLOSE(I)
          END DO
-         STOP
+         ERROR STOP
       END DO
 
       RETURN

--- a/src/appl/rmcdhf90_mpi/setmix.f90
+++ b/src/appl/rmcdhf90_mpi/setmix.f90
@@ -48,7 +48,7 @@
       CALL OPENFL (25, NAME, 'UNFORMATTED', 'NEW', IERR)
       IF (IERR /= 0) THEN
          WRITE (ISTDE, *) 'Error when opening ', NAME(1:LEN_TRIM(NAME))
-         STOP
+         ERROR STOP
       ENDIF
 !
 !   Write the file header

--- a/src/appl/rmcdhf90_mpi/setsum.f90
+++ b/src/appl/rmcdhf90_mpi/setsum.f90
@@ -31,7 +31,7 @@
       CALL OPENFL (24, FILNAM, FORM, STATUS, IERR)
       IF (IERR /= 0) THEN
          WRITE (ISTDE, *) 'Error when opening ', FILNAM
-         STOP
+         ERROR STOP
       ENDIF
 
       RETURN


### PR DESCRIPTION
A common problem with `rmcdhf` is that it fails to converge or runs into some other error condition, and then it aborts mid-calculation. The problem is that often it just exits with a `STOP` and so the exit code is not set. This makes is impossible to catch these errors in scripts.

So this PR changes (almost) all occurrences of `STOP` to `ERROR STOP` in both `rmcdhf` and `rmcdhf_mpi`. I have not actually inspected the `STOP` calls indivudually, but I assume that if `rmcdf` terminates prematurely, it is some sort of an error condition. If it turns out that some of them legitimately should exit with `0`, we can change them back.

* It should not affect the interactive workflow -- `STOP` and `ERROR STOP` both terminate the program. Same applies to scripted workflows that do _not_ check for the error code. However, in scripted workflows where the user checks for the error code, they should now catch bad `rmcdhf` runs earlier.
* The same change should be done for the other programs as well, but I would let someone else do that. `rmcdhf` is the one that is problematic for me, and one that often fails.
* This will not necessarily fix cases where `rmcdhf` errors but exits with a `0` -- I am pretty sure that there are heaps of `STOP` calls in the libraries as well that should be turned into `ERROR STOP`s (e.g. in `lib9290`).