### PR TITLE
New plotting tools

### DIFF
--- a/src/tool/Makefile
+++ b/src/tool/Makefile
@@ -1,7 +1,7 @@
 LIBS=-L ${GRASP}/lib/ -l9290 -lmod
 FC_MODULES=-I ${GRASP}/src/lib/lib9290 -I ${GRASP}/src/lib/libmod
 
-all:  ${GRASP}/bin/lscomp.pl ${GRASP}/bin/rsave ${GRASP}/bin/rasfsplit ${GRASP}/bin/rcsfblock ${GRASP}/bin/rcsfmr ${GRASP}/bin/rcsfsplit ${GRASP}/bin/rhfs_lsj ${GRASP}/bin/rlevelseV ${GRASP}/bin/rlevels ${GRASP}/bin/rmixaccumulate ${GRASP}/bin/rmixextract ${GRASP}/bin/rseqenergy ${GRASP}/bin/rseqhfs ${GRASP}/bin/rseqtrans ${GRASP}/bin/rtabhfs ${GRASP}/bin/rtablevels ${GRASP}/bin/rtabtrans1 ${GRASP}/bin/rtabtrans2 ${GRASP}/bin/rtabtransE1 ${GRASP}/bin/rwfnmchfmcdf ${GRASP}/bin/rwfnplot ${GRASP}/bin/rwfnrelabel ${GRASP}/bin/rwfnrotate ${GRASP}/bin/wfnplot
+all:  ${GRASP}/bin/lscomp.pl ${GRASP}/bin/rsave ${GRASP}/bin/rasfsplit ${GRASP}/bin/rcsfblock ${GRASP}/bin/rcsfmr ${GRASP}/bin/rcsfsplit ${GRASP}/bin/rhfs_lsj ${GRASP}/bin/rlevelseV ${GRASP}/bin/rlevels ${GRASP}/bin/rmixaccumulate ${GRASP}/bin/rmixextract ${GRASP}/bin/rseqenergy ${GRASP}/bin/rseqhfs ${GRASP}/bin/rseqtrans ${GRASP}/bin/rtabhfs ${GRASP}/bin/rtablevels ${GRASP}/bin/rtabtrans1 ${GRASP}/bin/rtabtrans2 ${GRASP}/bin/rtabtransE1 ${GRASP}/bin/rwfnmchfmcdf ${GRASP}/bin/rwfnplot ${GRASP}/bin/rwfnrelabel ${GRASP}/bin/rwfnrotate ${GRASP}/bin/wfnplot ${GRASP}/bin/rwfnpyplot ${GRASP}/bin/rwfntotxt
 
 ${GRASP}/bin/lscomp.pl: lscomp.pl
 	cp $^ $@
@@ -77,9 +77,16 @@ ${GRASP}/bin/rwfnrotate: rwfnrotate.o
 ${GRASP}/bin/wfnplot: wfnplot.o
 	$(FC) -o $@ $? $(FC_LD) $(LIBS) $(LAPACK_LIBS)
 
+${GRASP}/bin/rwfntotxt: rwfntotxt.o
+	$(FC) -o $@ $? $(FC_LD) $(LIBS) $(LAPACK_LIBS)
+
+${GRASP}/bin/rwfnpyplot: rwfnpyplot
+	cp $^ $@
+	chmod u+x $@
+
 %.o: %.f90
 	$(FC) -c $(FC_FLAGS) $(FC_MODULES) -o $@ $<
 
 clean:
-	-rm -f  ${GRASP}/bin/lscomp.pl ${GRASP}/bin/rsave ${GRASP}/bin/rasfsplit ${GRASP}/bin/rcsfblock ${GRASP}/bin/rcsfmr ${GRASP}/bin/rcsfsplit ${GRASP}/bin/rhfs_lsj ${GRASP}/bin/rlevelseV ${GRASP}/bin/rlevels ${GRASP}/bin/rmixaccumulate ${GRASP}/bin/rmixextract ${GRASP}/bin/rseqenergy ${GRASP}/bin/rseqhfs ${GRASP}/bin/rseqtrans ${GRASP}/bin/rtabhfs ${GRASP}/bin/rtablevels ${GRASP}/bin/rtabtrans1 ${GRASP}/bin/rtabtrans2 ${GRASP}/bin/rtabtransE1 ${GRASP}/bin/rwfnmchfmcdf ${GRASP}/bin/rwfnplot ${GRASP}/bin/rwfnrelabel ${GRASP}/bin/rwfnrotate ${GRASP}/bin/wfnplot
+	-rm -f  ${GRASP}/bin/lscomp.pl ${GRASP}/bin/rsave ${GRASP}/bin/rasfsplit ${GRASP}/bin/rcsfblock ${GRASP}/bin/rcsfmr ${GRASP}/bin/rcsfsplit ${GRASP}/bin/rhfs_lsj ${GRASP}/bin/rlevelseV ${GRASP}/bin/rlevels ${GRASP}/bin/rmixaccumulate ${GRASP}/bin/rmixextract ${GRASP}/bin/rseqenergy ${GRASP}/bin/rseqhfs ${GRASP}/bin/rseqtrans ${GRASP}/bin/rtabhfs ${GRASP}/bin/rtablevels ${GRASP}/bin/rtabtrans1 ${GRASP}/bin/rtabtrans2 ${GRASP}/bin/rtabtransE1 ${GRASP}/bin/rwfnmchfmcdf ${GRASP}/bin/rwfnplot ${GRASP}/bin/rwfnrelabel ${GRASP}/bin/rwfnrotate ${GRASP}/bin/wfnplot ${GRASP}/bin/rwfntotxt ${GRASP}/bin/rwfnpyplot
 	-rm -f *.o *.mod

--- a/src/tool/rwfnpyplot
+++ b/src/tool/rwfnpyplot
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import matplotlib.pyplot as plt
+import numpy as np
+import sys
+
+print("""
+  RWFNPYPLOT - Jon Grumer, Uppsala University, 2022
+  A simple python script to plot a single orbital
+  from a DBSR_HF or GRASP .plot file
+
+  Input file: <name>.plot [from dbsr_hf --out_plot=1, or the grasp tool: rwfntotxt]
+
+  For more info, run: rwfnpyplot --help
+  """)
+
+if len(sys.argv) > 1:
+    filename = sys.argv[1] # grasp or dbsr plot file name: 'name.plot'
+else:
+    sys.exit("""
+      Please provide correct command line arguments.
+      For more info, run: rwfnpyplot --help
+    """)
+
+if filename == "--help":
+    print("""
+    --help:
+
+      Run with 4 command line arguments as follows
+
+      >> rwfnplot <name>.plot <nls> <P/Q> <max-r> <y/n (plot to screen?)>
+
+      where nls is e.g. 2s or 6d-, P or Q selects large or small component
+      and max-r is the maximum plot radius. The last options controls whether
+      you want to plot to screen - if not, a pdf will be created instead.
+    """)
+    print("""
+      Program source file: {}
+    """.format(sys.argv[0]) )
+    sys.exit()
+
+if not len(sys.argv) >= 5:
+    sys.exit("""
+      Please provide correct command line arguments.
+
+      See rwfnpyplot --help for more info.
+    """)
+
+# get remaining control arguments
+nls            = sys.argv[2]        # orbital '1s' or '2p-'
+pq             = sys.argv[3]        # 'P' or 'Q' (or small letters)
+max_r          = float(sys.argv[4]) # max radius
+if len(sys.argv) == 6:
+    plot_to_screen = sys.argv[5]    # plot to screen? If not then save as pdf (default)
+    if plot_to_screen in ['True', 'T', 'y', 'Y']:
+        plot_to_screen = True
+else:
+    plot_to_screen = False
+
+orbital_grasp = pq.capitalize()+'('+nls+')'
+orbital_dbsr  = pq.lower()+nls
+
+if pq.capitalize() == 'P':
+    function_type = 'P'
+else:
+    function_type = 'Q'
+
+# start analyze <name>.plot and plot selected orbital
+first_line = True
+X, Y       = [], []
+
+for line in open(filename, 'r'):
+    if first_line:
+        # find which orbital to plot
+        i_orb = 1
+        for orb in line.split()[1:]:
+            if orb == orbital_grasp or orb == orbital_dbsr:
+                break
+            else:
+                i_orb += 1
+
+        # done with the header, move on to data
+        first_line = False
+        continue
+
+    values = [float(s) for s in line.split()]
+    X.append(values[0])
+    Y.append(values[i_orb])
+
+plt.axhline(y=0.0, color='black', lw=0.75, ls='--')
+plt.plot(X[1:], Y[1:], label = orbital_grasp)
+plt.xlabel('r[a.u.]')
+plt.ylabel(function_type+'(r)')
+plt.xlim([0,max_r])
+plt.legend()
+
+if plot_to_screen:
+    plt.show()
+else:
+    plt.savefig(filename.split(".")[0]+'_plot.pdf', bbox_inches='tight')

--- a/src/tool/rwfntotxt.f90
+++ b/src/tool/rwfntotxt.f90
@@ -1,0 +1,121 @@
+PROGRAM rwfntotxt
+
+   IMPLICIT NONE
+
+   integer, parameter                   :: npts0 = 10000 ! max number of gridpoints
+   integer, parameter                   :: nnnw  = 127   ! max no of orbitals
+   character(len=1), dimension(10), parameter :: l_str = ['s', 'p', 'd', 'f', 'g', 'h', 'i', 'k', 'l', 'm']
+
+   real(kind=8), dimension(npts0, nnnw) :: pg, qg, rg, pgg
+   real(kind=8)                         :: energy, a0
+   character(len=5), dimension(nnnw)    :: nl, selected_orbs
+   character                            :: title*6, orbl*4, n_str*2, new*3, xa*3, leg*50, format_string*50
+   integer(kind=4)                      :: np, lp, jp, nn, laky, ll, jj, npts, j, i, nwf, i_rg_max
+
+   write (*, *)
+   write (*, *) ' RWFNTOTXT - Jon Grumer, Uppsala University, 2022'
+   write (*, *) ' Converts binary GRASP wavefunctions to ASCII file format'
+   write (*, *)
+   write (*, *) '    Input: rwfn.inp      Output: rwfn.plot'
+   write (*, *)
+   write (*, *) '    Note: rwfnpyplot can be used to conveniently plot orbitals from the .plot file.'
+   write (*, *) '          E.g. >> rwfnpyplot rwfn.plot 2p- 50 y'
+   write (*, *) '          plots the large P(2p-) component to screen up to r = 50 au.'
+   write (*, *)
+
+   ! optional:
+   ! selected_orbs(1:2) = ['6s', '7s']
+
+   open (3, file='rwfn.inp', status='old', form='unformatted')
+   open (4, file='rwfn.plot', status='unknown')
+
+   ! write terminal info header
+   write(*, '(a32, a9)') 'max ', 'max'
+   write(*, '(a5, a7, a14, a7, a10, a6)') 'i', 'nl  ', 'E[a.u]      ', 'grid-n', 'r[a.u]', 'a0'
+
+   ! read binary orbital file
+   read (3) title
+   if (title .ne. 'G92RWF') then
+      print *, 'title = ', title, 'does not match G92RWF'
+      stop
+   end if
+
+   i = 1
+   do
+      read (3, end=20) nn, laky, energy, npts
+
+      write (n_str, '(i2)') nn
+      if (laky .gt. 0) then
+         ll = laky
+         jj = -1
+      elseif (laky .le. -1) then
+         ll = -laky - 1
+         jj = 1
+      else
+         write (*, *) 'Unexpected case when reading GRASP orbital wavefunction file'
+         stop
+      end if
+
+      ! define nl+/- in orbital array
+      if (jj .eq. 1) then
+         nl(i) = n_str//l_str(ll+1)//' '
+      else
+         nl(i) = n_str//l_str(ll+1)//'-'
+      end if
+
+      ! check grid
+      if (npts .gt. npts0) then
+         write (*, *) 'error: npts .gt. npts0'
+         stop
+      end if
+
+      ! read radial functions and grid
+      read (3) a0, (pg(j,i), j=1, npts), (qg(j,i), j=1, npts)
+      read (3) (rg(j,i), j=1, npts)
+
+      ! find radial grid of longest extent and use that as a common grid
+      ! in the output file
+      if (i .gt. 1) then
+         if ( maxval(rg(:,i)) .gt. maxval(rg(:,i-1)) ) then
+            i_rg_max = i
+         end if
+      end if
+
+      write(*, '(i5, a7, es14.6, i7, f10.2, es16.6)') i, nl(i), energy, npts, maxval(rg(:,i)), a0
+
+      ! increase orbital counter
+      i = i + 1
+
+   end do
+
+20 continue
+
+   ! number of orbitals
+   nwf = i - 1
+
+   ! write header
+   write (4, '(a14)', advance='no') 'r(a.u)'
+   do i = 1, nwf
+         !if ( any(selected_orbs == trim(adjustl(nl(i)))) ) then
+         write (4, '(a14)', advance='no') 'P('//trim(adjustl(nl(i)))//')'
+         write (4, '(a14)', advance='no') 'Q('//trim(adjustl(nl(i)))//')'
+         !end if
+   end do
+   write (4, *)
+
+   ! write r, P(r) and Q(r) for all orbitals
+   do j = 1, npts
+      write (4, '(es14.6)', advance='no') rg(j, nwf)
+      do i = 1, nwf
+         !if ( any(selected_orbs == trim(adjustl(nl(i)))) ) then
+         write (4, '(2es14.6)', advance='no') pg(j,i), qg(j,i)
+         !end if
+      end do
+      write (4, *)
+   end do
+
+   write(*,*)
+   write(*,*) ' Done! Radial wavefunctions printed to rwfn.plot.'
+   write(*,*)
+
+end program


### PR DESCRIPTION
For improved flexibility when it comes to plotting GRASP orbtial wavefunctions, I suggest we adopt the same format as used by DBSR_HF where the orbitals are dumped as columns in a text file. This file can then be used by a plotting tool of choice. Hope they will be of use to you all - it is indeed important to check your orbitals by eye!

New tools:
- `rwfntotxt`: converts a GRASP binary orbital file to ASCII
  Input: `rwfn.inp` --> Output: `rwfn.plot`
- `rwfnpyplot`: a python script that can be used to conveniently plot
  orbitals from a .plot file (from either `DBSR_HF` or` GRASP/rwfntotxt`)
  Run with command line arguments, e.g. to plot the large component of 2p- up to 50 a.u.
  ```bash
  >> rwfnpyplot rwfn.plot 2p- P 50 y
  ```
  The last option controls if you want to plot to screen or not - in which case a pdf is created instead.
  For more info, just run `rwfnpyplot --help`
  
  Cheers / Jon