### PR TITLE
rtabtransE1 - new mode (Grumer)

### DIFF
--- a/src/tool/rtabtransE1.f90
+++ b/src/tool/rtabtransE1.f90
@@ -5,7 +5,7 @@ program rtransitiontable
 ! Per Jonssson, Malmo University, August 2014
 
 implicit none
-integer, parameter :: ntrans = 100000
+integer, parameter :: ntrans = 1000000
 real(kind=8), parameter :: rydberg = 109737.31568508d0
 real(kind=8) :: Elev_upper(ntrans), Elev_lower(ntrans), Elev_groundst
 real(kind=8) :: twoJ_upper(ntrans), twoJ_lower(ntrans)
@@ -54,9 +54,6 @@ write(*,*) ' the label from 2s_2S.2p(2)3P2_4P'
 write(*,*)
 write(*,*) ' How many positions should be skipped?'
 read(*,*) nskip
-
-!write(*,*) 'Give the number of files'
-!iead(*,*) nfile
 
 write(19,'(a)') '\documentclass[10pt]{article}'
 write(19,'(a)') '\usepackage{longtable}'
@@ -147,27 +144,14 @@ do h = 1,nfile
          labelstring2(lastpos:lastpos) = ' '
       end select
 
-
-
-
-
-
-
       asciistring1(nt) = line1(21+nskip:200)
       asciistring2(nt) = line2(21+nskip:200)
 
-      ! 2J and total binding energy in a.u.
+      ! 2J value and total binding energy in a.u.
       j1 = line1(3:4)
       j2 = line2(3:4)
       read(line1(5:18),*) Elev_lower(nt)
       read(line2(5:18),*) Elev_upper(nt)
-
-!      energystring(nt) = line3(1:11)
-!      wavelengthstring(nt) = line3(17:29)
-!      sstring(nt) = line4(11:21)
-!      gfstring(nt) = line4(31:41)
-!      Astring(nt) = line4(52:62)
-!      dTstring(nt) = line4(70:78)
 
       energystring(nt) = line3(1:8)
       wavelengthstring(nt) = line3(17:29)
@@ -175,17 +159,13 @@ do h = 1,nfile
       gfstring(nt) = line4(31:35)//line4(38:41)
       Astring(nt) = line4(52:56)//line4(59:62)
       dTstring(nt) = line4(70:76)
-!      write(*,*) labelstring1
-!      write(*,*) labelstring2
 
-
-! Convert quantum labels
-! to LaTeX
-
+      ! Convert quantum labels
+      ! to LaTeX
 
       do i = 1,177
 
-!  Replace (n) with ^n
+      !  Replace (n) with ^n
 
          if ((labelstring1(i:i).eq.'(').and.(labelstring1(i+2:i+2).eq.')')) then
             labelstring1(i:i) = '^'
@@ -199,7 +179,7 @@ do h = 1,nfile
 
       do i = 1,177
 
-!  Replace . with \,
+      !  Replace . with \,
 
          if (labelstring1(i:i).eq.'.') then
             dummystring = labelstring1
@@ -219,16 +199,13 @@ do h = 1,nfile
 
       do i = 1,177
 
-!  Replace _ with ~
+      !  Replace _ with ~
 
          if (labelstring1(i:i).eq.'_') labelstring1(i:i) = '~'
          if (labelstring2(i:i).eq.'_') labelstring2(i:i) = '~'
       end do
-!      write(*,'(a)') trim(labelstring1)
-!      write(*,'(a)') trim(labelstring2)
 
-!  If integer1 and S, P, D, F, G, H, I, K, L, M, N and integer2 replace with (^integer1_integer2S), (^integer1_integer2P), etc
-
+      !  If integer1 and S, P, D, F, G, H, I, K, L, M, N and integer2 replace with (^integer1_integer2S), (^integer1_integer2P), etc
       do l = 1,15
          ncase = 0
          do i = 1,177
@@ -248,8 +225,6 @@ do h = 1,nfile
             end do
             if (ncase.eq.1) exit
          end do
-
-!         write(*,'(a)') trim(labelstring1)
       end do
 
       do l = 1,15
@@ -271,8 +246,6 @@ do h = 1,nfile
             end do
             if (ncase.eq.1) exit
          end do
-
-!         write(*,'(a)') trim(labelstring2)
       end do
 
 !  If integer1 and S, P, D, F, G, H, I, K, L, M, N and not integer2 replace with ^integer1S, ^integer1P, etc
@@ -340,50 +313,8 @@ do h = 1,nfile
       latexstring1(nt) = labelstring1
       latexstring2(nt) = labelstring2
 
-      !if (j1.eq.' 0') asciistring1(nt) = trim(asciistring1(nt))//' 0  '
-      !if (j2.eq.' 0') asciistring2(nt) = trim(asciistring2(nt))//' 0  '
-      !if (j1.eq.' 1') asciistring1(nt) = trim(asciistring1(nt))//' 1/2'
-      !if (j2.eq.' 1') asciistring2(nt) = trim(asciistring2(nt))//' 1/2'
-      !if (j1.eq.' 2') asciistring1(nt) = trim(asciistring1(nt))//' 1  '
-      !if (j2.eq.' 2') asciistring2(nt) = trim(asciistring2(nt))//' 1  '
-      !if (j1.eq.' 3') asciistring1(nt) = trim(asciistring1(nt))//' 3/2'
-      !if (j2.eq.' 3') asciistring2(nt) = trim(asciistring2(nt))//' 3/2'
-      !if (j1.eq.' 4') asciistring1(nt) = trim(asciistring1(nt))//' 2  '
-      !if (j2.eq.' 4') asciistring2(nt) = trim(asciistring2(nt))//' 2  '
-      !if (j1.eq.' 5') asciistring1(nt) = trim(asciistring1(nt))//' 5/2'
-      !if (j2.eq.' 5') asciistring2(nt) = trim(asciistring2(nt))//' 5/2'
-      !if (j1.eq.' 6') asciistring1(nt) = trim(asciistring1(nt))//' 3  '
-      !if (j2.eq.' 6') asciistring2(nt) = trim(asciistring2(nt))//' 3  '
-      !if (j1.eq.' 7') asciistring1(nt) = trim(asciistring1(nt))//' 7/2'
-      !if (j2.eq.' 7') asciistring2(nt) = trim(asciistring2(nt))//' 7/2'
-      !if (j1.eq.' 8') asciistring1(nt) = trim(asciistring1(nt))//' 4  '
-      !if (j2.eq.' 8') asciistring2(nt) = trim(asciistring2(nt))//' 4  '
-      !if (j1.eq.' 9') asciistring1(nt) = trim(asciistring1(nt))//' 9/2'
-      !if (j2.eq.' 9') asciistring2(nt) = trim(asciistring2(nt))//' 9/2'
-      !if (j1.eq.'10') asciistring1(nt) = trim(asciistring1(nt))//' 5  '
-      !if (j2.eq.'10') asciistring2(nt) = trim(asciistring2(nt))//' 5  '
-      !if (j1.eq.'11') asciistring1(nt) = trim(asciistring1(nt))//' 11/2'
-      !if (j2.eq.'11') asciistring2(nt) = trim(asciistring2(nt))//' 11/2'
-      !if (j1.eq.'12') asciistring1(nt) = trim(asciistring1(nt))//' 6  '
-      !if (j2.eq.'12') asciistring2(nt) = trim(asciistring2(nt))//' 6  '
-      !if (j1.eq.'13') asciistring1(nt) = trim(asciistring1(nt))//' 13/2'
-      !if (j2.eq.'13') asciistring2(nt) = trim(asciistring2(nt))//' 13/2'
-      !if (j1.eq.'14') asciistring1(nt) = trim(asciistring1(nt))//' 7  '
-      !if (j2.eq.'14') asciistring2(nt) = trim(asciistring2(nt))//' 7  '
-      !if (j1.eq.'15') asciistring1(nt) = trim(asciistring1(nt))//' 15/2'
-      !if (j2.eq.'15') asciistring2(nt) = trim(asciistring2(nt))//' 15/2'
-      !if (j1.eq.'16') asciistring1(nt) = trim(asciistring1(nt))//' 8  '
-      !if (j2.eq.'16') asciistring2(nt) = trim(asciistring2(nt))//' 8  '
-      !if (j1.eq.'17') asciistring1(nt) = trim(asciistring1(nt))//' 17/2'
-      !if (j2.eq.'17') asciistring2(nt) = trim(asciistring2(nt))//' 17/2'
-      !if (j1.eq.'18') asciistring1(nt) = trim(asciistring1(nt))//' 9  '
-      !if (j2.eq.'18') asciistring2(nt) = trim(asciistring2(nt))//' 9  '
-      !if (j1.eq.'19') asciistring1(nt) = trim(asciistring1(nt))//' 19/2'
-      !if (j2.eq.'19') asciistring2(nt) = trim(asciistring2(nt))//' 19/2'
-
       if (len_trim(asciistring1(nt)).gt.maxlengthascii1) maxlengthascii1 = len_trim(asciistring1(nt))
       if (len_trim(asciistring2(nt)).gt.maxlengthascii2) maxlengthascii2 = len_trim(asciistring2(nt))
-
 
       ! use numerical J-values for the ASCII print out
       read(j1,*) twoJ_lower(nt); write(j1_numerical(nt),'(f4.1)') twoJ_lower(nt)/2.0
@@ -398,8 +329,8 @@ do h = 1,nfile
    do i = 1,nt
 
       ! get energy levels in cm-1 relative to the lowest state in the list
-      write(El_str,'(i8)') int((Elev_lower(i) - Elev_groundst)*rydberg*2d0, kind=8)
-      write(Eu_str,'(i8)') int((Elev_upper(i) - Elev_groundst)*rydberg*2d0, kind=8)
+      write(El_str,'(i8)') int((Elev_lower(i) - Elev_groundst)*rydberg*2.d0, kind=8)
+      write(Eu_str,'(i8)') int((Elev_upper(i) - Elev_groundst)*rydberg*2.d0, kind=8)
 
       ! print latex file
       if (nformat.eq.0) then
@@ -480,6 +411,3 @@ write(19,'(a)') '\end{document}'
 end do
 
 end program rtransitiontable
-
-
-

--- a/src/tool/rtabtransE1.f90
+++ b/src/tool/rtabtransE1.f90
@@ -6,10 +6,14 @@ program rtransitiontable
 
 implicit none
 integer, parameter :: ntrans = 100000
+real(kind=8), parameter :: rydberg = 109737.31568508d0
+real(kind=8) :: Elev_upper(ntrans), Elev_lower(ntrans), Elev_groundst
+real(kind=8) :: twoJ_upper(ntrans), twoJ_lower(ntrans)
 integer :: h,i,j,k,l, nfile, ntransition, ncase, maxlengthascii1, maxlengthlatex1
 integer :: maxlengthascii2, maxlengthlatex2, nt, nformat, nskip, lastpos
 character(len=1) :: char1, char2, char3
-character(len=2) :: j1,j2
+character(len=2) :: j1, j2
+character(len=4) :: j1_numerical(ntrans), j2_numerical(ntrans)
 character(len=100) :: filename
 character(len=200) :: line1, line2, line3, line4, line5, line6, line7, linedummy
 character(len=180) :: labelstring1, labelstring2, dummystring
@@ -19,6 +23,7 @@ character(len=1) :: extra1(ntrans), extra2(ntrans)
 character(len=8) :: energystring(ntrans)
 character(len=13) :: wavelengthstring(ntrans)
 character(len=7) :: dTstring(ntrans)
+character(len=8) :: El_str, Eu_str
 
 open(unit=19,file='transitiontable.tex',status='unknown')
 open(unit=20,file='transitiontableascii.txt',status='unknown')
@@ -32,6 +37,7 @@ write(*,*) ' Output file: transitiontable.tex'
 write(*,*)
 
 write(*,*) ' Specify table format '
+write(*,*) ' (0). Lower & Energy & Upper & Energy & Energy diff. & wavelength & S & gf & A & dT '
 write(*,*) ' (1). Lower & Upper & Energy diff. & wavelength & S & gf & A & dT '
 write(*,*) ' (2). Lower & Upper & Energy diff. & wavelength & gf & A & dT '
 write(*,*) ' (3). Lower & Upper & Energy diff. & wavelength & gf & A '
@@ -50,14 +56,17 @@ write(*,*) ' How many positions should be skipped?'
 read(*,*) nskip
 
 !write(*,*) 'Give the number of files'
-!read(*,*) nfile
+!iead(*,*) nfile
 
 write(19,'(a)') '\documentclass[10pt]{article}'
 write(19,'(a)') '\usepackage{longtable}'
 write(19,'(a)') '\begin{document}'
 
-
-if (nformat.eq.1) then
+if (nformat.eq.0) then
+   write(19,'(a)') '\begin{longtable}{lrlrrrrrrr}'
+   write(19,'(a)',advance='no') 'Lower state & E (cm$^{-1}$) & Upper state & E (cm$^{-1}$) '
+   write(19,'(a)') '& $\Delta E$ (cm$^{-1}$) & $\lambda$ (\AA) &$S$&$gf$& $A$ (s$^{-1}$)&$dT$ \\ \hline'
+elseif (nformat.eq.1) then
    write(19,'(a)') '\begin{longtable}{llrrrrrr}'
    write(19,'(a)') 'Lower state & Upper state & $\Delta E$ (cm$^{-1}$) & $\lambda$ (\AA) &$S$&$gf$& $A$ (s$^{-1}$)&$dT$ \\ \hline'
 elseif (nformat.eq.2) then
@@ -114,6 +123,7 @@ do h = 1,nfile
          stop
       end if
 
+
       labelstring1 = line1(21+nskip:200)
       labelstring2 = line2(21+nskip:200)
 
@@ -145,8 +155,12 @@ do h = 1,nfile
 
       asciistring1(nt) = line1(21+nskip:200)
       asciistring2(nt) = line2(21+nskip:200)
+
+      ! 2J and total binding energy in a.u.
       j1 = line1(3:4)
       j2 = line2(3:4)
+      read(line1(5:18),*) Elev_lower(nt)
+      read(line2(5:18),*) Elev_upper(nt)
 
 !      energystring(nt) = line3(1:11)
 !      wavelengthstring(nt) = line3(17:29)
@@ -326,86 +340,112 @@ do h = 1,nfile
       latexstring1(nt) = labelstring1
       latexstring2(nt) = labelstring2
 
-      if (j1.eq.' 0') asciistring1(nt) = trim(asciistring1(nt))//' 0  '
-      if (j2.eq.' 0') asciistring2(nt) = trim(asciistring2(nt))//' 0  '
-      if (j1.eq.' 1') asciistring1(nt) = trim(asciistring1(nt))//' 1/2'
-      if (j2.eq.' 1') asciistring2(nt) = trim(asciistring2(nt))//' 1/2'
-      if (j1.eq.' 2') asciistring1(nt) = trim(asciistring1(nt))//' 1  '
-      if (j2.eq.' 2') asciistring2(nt) = trim(asciistring2(nt))//' 1  '
-      if (j1.eq.' 3') asciistring1(nt) = trim(asciistring1(nt))//' 3/2'
-      if (j2.eq.' 3') asciistring2(nt) = trim(asciistring2(nt))//' 3/2'
-      if (j1.eq.' 4') asciistring1(nt) = trim(asciistring1(nt))//' 2  '
-      if (j2.eq.' 4') asciistring2(nt) = trim(asciistring2(nt))//' 2  '
-      if (j1.eq.' 5') asciistring1(nt) = trim(asciistring1(nt))//' 5/2'
-      if (j2.eq.' 5') asciistring2(nt) = trim(asciistring2(nt))//' 5/2'
-      if (j1.eq.' 6') asciistring1(nt) = trim(asciistring1(nt))//' 3  '
-      if (j2.eq.' 6') asciistring2(nt) = trim(asciistring2(nt))//' 3  '
-      if (j1.eq.' 7') asciistring1(nt) = trim(asciistring1(nt))//' 7/2'
-      if (j2.eq.' 7') asciistring2(nt) = trim(asciistring2(nt))//' 7/2'
-      if (j1.eq.' 8') asciistring1(nt) = trim(asciistring1(nt))//' 4  '
-      if (j2.eq.' 8') asciistring2(nt) = trim(asciistring2(nt))//' 4  '
-      if (j1.eq.' 9') asciistring1(nt) = trim(asciistring1(nt))//' 9/2'
-      if (j2.eq.' 9') asciistring2(nt) = trim(asciistring2(nt))//' 9/2'
-      if (j1.eq.'10') asciistring1(nt) = trim(asciistring1(nt))//' 5  '
-      if (j2.eq.'10') asciistring2(nt) = trim(asciistring2(nt))//' 5  '
-      if (j1.eq.'11') asciistring1(nt) = trim(asciistring1(nt))//' 11/2'
-      if (j2.eq.'11') asciistring2(nt) = trim(asciistring2(nt))//' 11/2'
-      if (j1.eq.'12') asciistring1(nt) = trim(asciistring1(nt))//' 6  '
-      if (j2.eq.'12') asciistring2(nt) = trim(asciistring2(nt))//' 6  '
-      if (j1.eq.'13') asciistring1(nt) = trim(asciistring1(nt))//' 13/2'
-      if (j2.eq.'13') asciistring2(nt) = trim(asciistring2(nt))//' 13/2'
-      if (j1.eq.'14') asciistring1(nt) = trim(asciistring1(nt))//' 7  '
-      if (j2.eq.'14') asciistring2(nt) = trim(asciistring2(nt))//' 7  '
-      if (j1.eq.'15') asciistring1(nt) = trim(asciistring1(nt))//' 15/2'
-      if (j2.eq.'15') asciistring2(nt) = trim(asciistring2(nt))//' 15/2'
-      if (j1.eq.'16') asciistring1(nt) = trim(asciistring1(nt))//' 8  '
-      if (j2.eq.'16') asciistring2(nt) = trim(asciistring2(nt))//' 8  '
-      if (j1.eq.'17') asciistring1(nt) = trim(asciistring1(nt))//' 17/2'
-      if (j2.eq.'17') asciistring2(nt) = trim(asciistring2(nt))//' 17/2'
-      if (j1.eq.'18') asciistring1(nt) = trim(asciistring1(nt))//' 9  '
-      if (j2.eq.'18') asciistring2(nt) = trim(asciistring2(nt))//' 9  '
-      if (j1.eq.'19') asciistring1(nt) = trim(asciistring1(nt))//' 19/2'
-      if (j2.eq.'19') asciistring2(nt) = trim(asciistring2(nt))//' 19/2'
+      !if (j1.eq.' 0') asciistring1(nt) = trim(asciistring1(nt))//' 0  '
+      !if (j2.eq.' 0') asciistring2(nt) = trim(asciistring2(nt))//' 0  '
+      !if (j1.eq.' 1') asciistring1(nt) = trim(asciistring1(nt))//' 1/2'
+      !if (j2.eq.' 1') asciistring2(nt) = trim(asciistring2(nt))//' 1/2'
+      !if (j1.eq.' 2') asciistring1(nt) = trim(asciistring1(nt))//' 1  '
+      !if (j2.eq.' 2') asciistring2(nt) = trim(asciistring2(nt))//' 1  '
+      !if (j1.eq.' 3') asciistring1(nt) = trim(asciistring1(nt))//' 3/2'
+      !if (j2.eq.' 3') asciistring2(nt) = trim(asciistring2(nt))//' 3/2'
+      !if (j1.eq.' 4') asciistring1(nt) = trim(asciistring1(nt))//' 2  '
+      !if (j2.eq.' 4') asciistring2(nt) = trim(asciistring2(nt))//' 2  '
+      !if (j1.eq.' 5') asciistring1(nt) = trim(asciistring1(nt))//' 5/2'
+      !if (j2.eq.' 5') asciistring2(nt) = trim(asciistring2(nt))//' 5/2'
+      !if (j1.eq.' 6') asciistring1(nt) = trim(asciistring1(nt))//' 3  '
+      !if (j2.eq.' 6') asciistring2(nt) = trim(asciistring2(nt))//' 3  '
+      !if (j1.eq.' 7') asciistring1(nt) = trim(asciistring1(nt))//' 7/2'
+      !if (j2.eq.' 7') asciistring2(nt) = trim(asciistring2(nt))//' 7/2'
+      !if (j1.eq.' 8') asciistring1(nt) = trim(asciistring1(nt))//' 4  '
+      !if (j2.eq.' 8') asciistring2(nt) = trim(asciistring2(nt))//' 4  '
+      !if (j1.eq.' 9') asciistring1(nt) = trim(asciistring1(nt))//' 9/2'
+      !if (j2.eq.' 9') asciistring2(nt) = trim(asciistring2(nt))//' 9/2'
+      !if (j1.eq.'10') asciistring1(nt) = trim(asciistring1(nt))//' 5  '
+      !if (j2.eq.'10') asciistring2(nt) = trim(asciistring2(nt))//' 5  '
+      !if (j1.eq.'11') asciistring1(nt) = trim(asciistring1(nt))//' 11/2'
+      !if (j2.eq.'11') asciistring2(nt) = trim(asciistring2(nt))//' 11/2'
+      !if (j1.eq.'12') asciistring1(nt) = trim(asciistring1(nt))//' 6  '
+      !if (j2.eq.'12') asciistring2(nt) = trim(asciistring2(nt))//' 6  '
+      !if (j1.eq.'13') asciistring1(nt) = trim(asciistring1(nt))//' 13/2'
+      !if (j2.eq.'13') asciistring2(nt) = trim(asciistring2(nt))//' 13/2'
+      !if (j1.eq.'14') asciistring1(nt) = trim(asciistring1(nt))//' 7  '
+      !if (j2.eq.'14') asciistring2(nt) = trim(asciistring2(nt))//' 7  '
+      !if (j1.eq.'15') asciistring1(nt) = trim(asciistring1(nt))//' 15/2'
+      !if (j2.eq.'15') asciistring2(nt) = trim(asciistring2(nt))//' 15/2'
+      !if (j1.eq.'16') asciistring1(nt) = trim(asciistring1(nt))//' 8  '
+      !if (j2.eq.'16') asciistring2(nt) = trim(asciistring2(nt))//' 8  '
+      !if (j1.eq.'17') asciistring1(nt) = trim(asciistring1(nt))//' 17/2'
+      !if (j2.eq.'17') asciistring2(nt) = trim(asciistring2(nt))//' 17/2'
+      !if (j1.eq.'18') asciistring1(nt) = trim(asciistring1(nt))//' 9  '
+      !if (j2.eq.'18') asciistring2(nt) = trim(asciistring2(nt))//' 9  '
+      !if (j1.eq.'19') asciistring1(nt) = trim(asciistring1(nt))//' 19/2'
+      !if (j2.eq.'19') asciistring2(nt) = trim(asciistring2(nt))//' 19/2'
 
       if (len_trim(asciistring1(nt)).gt.maxlengthascii1) maxlengthascii1 = len_trim(asciistring1(nt))
       if (len_trim(asciistring2(nt)).gt.maxlengthascii2) maxlengthascii2 = len_trim(asciistring2(nt))
 
+
+      ! use numerical J-values for the ASCII print out
+      read(j1,*) twoJ_lower(nt); write(j1_numerical(nt),'(f4.1)') twoJ_lower(nt)/2.0
+      read(j2,*) twoJ_upper(nt); write(j2_numerical(nt),'(f4.1)') twoJ_upper(nt)/2.0
+
    end do
 999 continue
 
+   ! find lowest total energy
+   Elev_groundst = minval(Elev_lower)
+
    do i = 1,nt
-      if (nformat.eq.1) then
+
+      ! get energy levels in cm-1 relative to the lowest state in the list
+      write(El_str,'(i8)') int((Elev_lower(i) - Elev_groundst)*rydberg*2d0, kind=8)
+      write(Eu_str,'(i8)') int((Elev_upper(i) - Elev_groundst)*rydberg*2d0, kind=8)
+
+      ! print latex file
+      if (nformat.eq.0) then
+      write(19,'(a)') latexstring1(i)(1:maxlengthlatex1)//'~'//extra1(i)//' & '//El_str//' & '//&
+                     &latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//Eu_str//' & '//&
+                     &energystring(i)//' & '//wavelengthstring(i)//' & '//sstring(i)//' & '//gfstring(i)//' & '//&
+                     &Astring(i)//' & '//dTstring(i)//'\\'
+      elseif (nformat.eq.1) then
       write(19,'(a)') latexstring1(i)(1:maxlengthlatex1)//'~'//extra1(i)//' & '//&
-                     & latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
+                     &latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
                      &energystring(i)//' & '//wavelengthstring(i)//' & '//sstring(i)//' & '//gfstring(i)//' & '//&
                      &Astring(i)//' & '//dTstring(i)//'\\'
       elseif (nformat.eq.2) then
       write(19,'(a)') latexstring1(i)(1:maxlengthlatex1)//'~'//extra1(i)//' & '//&
-                     & latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
+                     &latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
                      &energystring(i)//' & '//wavelengthstring(i)//' & '//gfstring(i)//' & '//&
                      &Astring(i)//' & '//dTstring(i)//'\\'
       elseif (nformat.eq.3) then
       write(19,'(a)') latexstring1(i)(1:maxlengthlatex1)//'~'//extra1(i)//' & '//&
-                     & latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
+                     &latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
                      &energystring(i)//' & '//wavelengthstring(i)//' & '//gfstring(i)//' & '//&
                      &Astring(i)//'\\'
       elseif (nformat.eq.4) then
       write(19,'(a)') latexstring1(i)(1:maxlengthlatex1)//'~'//extra1(i)//' & '//&
-                     & latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
+                     &latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
                      &energystring(i)//' & '//sstring(i)//' & '//gfstring(i)//' & '//&
                      &Astring(i)//' & '//dTstring(i)//'\\'
       elseif (nformat.eq.5) then
       write(19,'(a)') latexstring1(i)(1:maxlengthlatex1)//'~'//extra1(i)//' & '//&
-                     & latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
+                     &latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
                      &energystring(i)//' & '//gfstring(i)//' & '//&
                      &Astring(i)//' & '//dTstring(i)//'\\'
       elseif (nformat.eq.6) then
       write(19,'(a)') latexstring1(i)(1:maxlengthlatex1)//'~'//extra1(i)//' & '//&
-                     & latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
+                     &latexstring2(i)(1:maxlengthlatex2)//'~'//extra2(i)//' & '//&
                      &energystring(i)//' & '//gfstring(i)//' & '//&
                      &Astring(i)//'\\'
       end if
-      if (nformat.eq.1) then
+
+      ! print ascii file
+      if (nformat.eq.0) then
+      write(20,'(a)') asciistring1(i)(1:maxlengthascii1)//'  '//j1_numerical(i)//'  '//El_str//'  '//&
+                     &asciistring2(i)(1:maxlengthascii2)//'  '//j2_numerical(i)//'  '//Eu_str//'  '//&
+                     &energystring(i)//'  '//wavelengthstring(i)//'  '//sstring(i)//'  '//gfstring(i)//'  '//&
+                     &Astring(i)//'  '//dTstring(i)
+      elseif (nformat.eq.1) then
       write(20,'(a)') asciistring1(i)(1:maxlengthascii1)//'  '// asciistring2(i)(1:maxlengthascii2)//'  '//&
                      &energystring(i)//'  '//wavelengthstring(i)//'  '//sstring(i)//'  '//gfstring(i)//'  '//&
                      &Astring(i)//'  '//dTstring(i)


### PR DESCRIPTION
New mode (mode 0) which includes printing of the level energies in the line lists - this is needed in most plasma/astrophysical applications to determine level populations.

We should add the same possibility to the ratbtrans1 + rtabtrans2 codes - for these codes it would also be good to have the possibility to print the lifetimes of the levels in the line-list, in order to estimate the radiative broadening of the level. I'll add this to issues.

And yes @mortenpi there  are some formatting changes, including whitespaces, but since no-one really checks these updates anyway, I might as well do some cleaning ;)