### PR TITLE
rwfnestimate -- output <r> for each orbital

### DIFF
--- a/src/appl/rwfnestimate90/summry.f90
+++ b/src/appl/rwfnestimate90/summry.f90
@@ -14,6 +14,7 @@
 !***********************************************************************
 !
 !...Translated by Pacific-Sierra Research 77to90  4.3E  11:06:21   1/ 2/07
+!...Modified by Yanting Li, output <r> for each orbital, 19 Aug 2022
 !-----------------------------------------------
 !   M o d u l e s
 !-----------------------------------------------
@@ -25,6 +26,7 @@
 !-----------------------------------------------
 !   I n t e r f a c e   B l o c k s
 !-----------------------------------------------
+      USE rint_I
       IMPLICIT NONE
 !-----------------------------------------------
 !   D u m m y   A r g u m e n t s
@@ -41,16 +43,24 @@
 !
       DO I = 1, NW
          LENTH = LEN_TRIM(SOURCE(I))
-         WRITE (NUNIT, 301) NP(I), NH(I), E(I), PZ(I), GAMA(I), PF(2,I), QF(2,I&
-            ), MF(I), SOURCE(I)(1:LENTH)
+!--------Output P(2) and Q(2) for each orbital
+!         WRITE (NUNIT, 301) NP(I), NH(I), E(I), PZ(I), GAMA(I), PF(2,I), QF(2,I&
+!            ), MF(I), SOURCE(I)(1:LENTH)
+!--------Output <r> (RINT(I,I,1)) for each orbital
+         WRITE (NUNIT, 301) NP(I), NH(I), E(I), PZ(I), GAMA(I), RINT(I,I,1)&
+             , MF(I), SOURCE(I)(1:LENTH)
 !         WRITE (NUNIT,302) SOURCE(I)(1:LENTH)
       END DO
 !
       RETURN
 !
-  300 FORMAT('Shell',6X,'e',11X,'p0',8X,'gamma',8X,'P(2)',7X,'Q(2)',6X,'MTP',&
-         '  SRC'/)
-  301 FORMAT(1X,I2,A2,5D12.4,I5,2X,A3)
+!-Format for P(2) and Q(2)
+!  300 FORMAT('Shell',6X,'e',11X,'p0',8X,'gamma',8X,'P(2)',7X,'Q(2)',6X,'MTP',&
+!         '  SRC'/)
+!  301 FORMAT(1X,I2,A2,5D12.4,I5,2X,A3)
+!-Format for <r>
+  300 FORMAT('Shell',6X,'e',11X,'p0',8X,'gamma',8X,'<r>',6X,'MTP','  SRC'/)
+  301 FORMAT(1X,I2,A2,4D12.4,I5,2X,A3)
       RETURN
 !  302 FORMAT ('      Source: ',A)
 !


### PR DESCRIPTION
*Output <r> instead of P(2) and Q(2) at the end to make full use of the option with user supplied Z.

*P(2) and Q(2) are commented out and can be replaced if needed.