### PR TITLE
DOC: Update readme for rank mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ simply call `make`:
 cd build/ && make install
 ```
 
+This may fail with rank mismatch errors. In this case, for `gfortran` consider:
+
+```sh
+# Inside build
+cmake -DCMAKE_Fortran_FLAGS="-std=legacy" .
+cmake --build . --parallel
+cmake --install .
+```
+
 Remarks:
 
 * Running `make install` instructs CMake to actually _install_ the resulting binaries into


### PR DESCRIPTION
As noted. The actual error is:

```fortran
grasp/src/lib/lib9290/iniest2.f90:82:23:

   79 |          CALL DCOPY (NS, VEC(NS*(J-1)+1), 1, BASIS(NCF*(J-1)+1), 1)
      |                         2
......
   82 |       CALL DCOPY (NIV, EIGVAL, 1, BASIS(NIV*NCF+1), 1)
      |                       1
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
```